### PR TITLE
PodMidi fixes

### DIFF
--- a/pod/PodMidi/PodMidi-Debug.vgdbsettings
+++ b/pod/PodMidi/PodMidi-Debug.vgdbsettings
@@ -40,7 +40,7 @@
   </CustomDebug>
   <DeviceTerminalSettings>
     <Connection xsi:type="com.sysprogs.terminal.connection.serial">
-      <ComPortName>COM5</ComPortName>
+      <ComPortName>COM59</ComPortName>
       <AdvancedSettings>
         <BaudRate>115200</BaudRate>
         <DataBits>8</DataBits>
@@ -125,14 +125,14 @@
     <AdditionalGDBSettings>
       <Features>
         <DisableAutoDetection>false</DisableAutoDetection>
-        <UseFrameParameter>false</UseFrameParameter>
-        <SimpleValuesFlagSupported>false</SimpleValuesFlagSupported>
-        <ListLocalsSupported>false</ListLocalsSupported>
-        <ByteLevelMemoryCommandsAvailable>false</ByteLevelMemoryCommandsAvailable>
-        <ThreadInfoSupported>false</ThreadInfoSupported>
-        <PendingBreakpointsSupported>false</PendingBreakpointsSupported>
-        <SupportTargetCommand>false</SupportTargetCommand>
-        <ReliableBreakpointNotifications>false</ReliableBreakpointNotifications>
+        <UseFrameParameter>true</UseFrameParameter>
+        <SimpleValuesFlagSupported>true</SimpleValuesFlagSupported>
+        <ListLocalsSupported>true</ListLocalsSupported>
+        <ByteLevelMemoryCommandsAvailable>true</ByteLevelMemoryCommandsAvailable>
+        <ThreadInfoSupported>true</ThreadInfoSupported>
+        <PendingBreakpointsSupported>true</PendingBreakpointsSupported>
+        <SupportTargetCommand>true</SupportTargetCommand>
+        <ReliableBreakpointNotifications>true</ReliableBreakpointNotifications>
       </Features>
       <EnableSmartStepping>false</EnableSmartStepping>
       <FilterSpuriousStoppedNotifications>false</FilterSpuriousStoppedNotifications>
@@ -144,7 +144,7 @@
       <UseRelativePathsOnly>false</UseRelativePathsOnly>
       <ExitAction>None</ExitAction>
       <DisableDisassembly>false</DisableDisassembly>
-      <ExamineMemoryWithXCommand>false</ExamineMemoryWithXCommand>
+      <ExamineMemoryWithXCommand>true</ExamineMemoryWithXCommand>
       <StepIntoNewInstanceEntry>main</StepIntoNewInstanceEntry>
       <ExamineRegistersInRawFormat>true</ExamineRegistersInRawFormat>
       <DisableSignals>false</DisableSignals>

--- a/pod/PodMidi/PodMidi.cpp
+++ b/pod/PodMidi/PodMidi.cpp
@@ -30,6 +30,10 @@ void HandleMidiMessage(MidiEvent m)
         case NoteOn:
         {
             NoteOnEvent p = m.AsNoteOn();
+			char buff[512];
+			sprintf(
+				buff, "Note Received:\t%d\t%d\t%d\r\n", m.channel, m.data[0], m.data[1]);
+			hw.seed.usb_handle.TransmitInternal((uint8_t*)buff, strlen(buff));
             // This is to avoid Max/MSP Note outs for now..
             if(m.data[1] != 0)
             {
@@ -67,7 +71,8 @@ int main(void)
     // Init
     float samplerate;
     hw.Init();
-    hw.seed.usb_handle.Init(UsbHandle::FS_EXTERNAL);
+    hw.seed.usb_handle.Init(UsbHandle::FS_INTERNAL);
+    dsy_system_delay(250);
     midi.Init(MidiHandler::INPUT_MODE_UART1, MidiHandler::OUTPUT_MODE_NONE);
 
     // Synthesis
@@ -77,9 +82,9 @@ int main(void)
     filt.Init(samplerate);
 
     // Start stuff.
-    midi.StartReceive();
     hw.StartAdc();
     hw.StartAudio(AudioCallback);
+    midi.StartReceive();
     for(;;)
     {
         midi.Listen();


### PR DESCRIPTION
added USB printout of incoming notes, and fixed init order. The order of init was allowing the RxFifo to become overflowed before the main loop started.

This is mostly just a bandaid to make sure it works when rebooting with MIDI incoming.

However, this should/can be resolved in the UART Callback handling for Writing to the FIFO in the MIDI object.