### PR TITLE
Patch Noise Example

### DIFF
--- a/patch/Noise/Makefile
+++ b/patch/Noise/Makefile
@@ -1,0 +1,14 @@
+# Project Name
+TARGET = Noise
+
+# Sources
+CPP_SOURCES = Noise.cpp
+
+# Library Locations
+LIBDAISY_DIR = ../../libdaisy
+DAISYSP_DIR = ../../DaisySP
+
+# Core location, and generic Makefile.
+SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
+include $(SYSTEM_FILES_DIR)/Makefile
+

--- a/patch/Noise/Noise.cpp
+++ b/patch/Noise/Noise.cpp
@@ -7,26 +7,99 @@ using namespace daisysp;
 
 DaisyPatch patch;
 
+WhiteNoise noise;
+
+struct filter{
+    Svf filt;
+    
+    enum mode { LOW, HIGH, BAND, NOTCH, PEAK, LAST, };
+    mode filterMode;
+
+    Parameter resParam, cutoffParam;
+
+    void Init(float samplerate, mode setMode, AnalogControl cutKnob, AnalogControl resKnob)
+    {
+        filt.Init(samplerate);
+        filterMode = setMode;
+
+        cutoffParam.Init(cutKnob, 20, 10000, Parameter::LOGARITHMIC);
+        resParam.Init(resKnob, 0, 1, Parameter::LINEAR);
+    }
+
+    void UpdateControls()
+    {
+        filt.SetFreq(cutoffParam.Process());
+        filt.SetRes(resParam.Process());
+    }
+
+    float Process(float in)
+    {
+        filt.Process(in);
+        switch (filterMode)
+        {
+            case mode::LOW:
+                return filt.Low();
+            case mode::HIGH:
+                return filt.High();
+            case mode::BAND:
+                return filt.Band();
+            case mode::NOTCH:
+                return filt.Notch();
+            case mode::PEAK:
+                return filt.Peak();
+            default:
+                break;
+        }
+        return 0.f;
+    }
+};
+
+filter lowpass, highpass;
+
 static void AudioCallback(float **in, float **out, size_t size)
 {
+    patch.UpdateAnalogControls();
+
+    lowpass.UpdateControls();
+    highpass.UpdateControls();
+
     for (size_t i = 0; i < size; i += 2)
     {
+        float sig = noise.Process();
+        sig = lowpass.Process(sig);
+        sig = highpass.Process(sig);
+
         for (size_t chn = 0; chn < 4; chn++)
         {
-            out[chn][i] = 0.f;
+            out[chn][i] = sig;
         }
     }
 }
+
+void UpdateControls();
+void UpdateOled();
 
 int main(void)
 {
     float samplerate;
     patch.Init(); // Initialize hardware (daisy seed, and patch)
     samplerate = patch.AudioSampleRate();
-   
+
+    noise.Init();
+    lowpass.Init(samplerate, filter::mode::LOW, patch.controls[0], patch.controls[1]);
+    highpass.Init(samplerate, filter::mode::HIGH, patch.controls[2], patch.controls[3]);
+
+    std::string str = "Noise";
+    char *cstr = &str[0];
+    patch.display.WriteString(cstr, Font_7x10, true);
+    patch.display.Update();
+    patch.DelayMs(1000);
+
     patch.StartAdc();
     patch.StartAudio(AudioCallback);
     while(1) 
     {
+        patch.DisplayControls(false);
     }
 }
+

--- a/patch/Noise/Noise.cpp
+++ b/patch/Noise/Noise.cpp
@@ -1,0 +1,32 @@
+#include "daisysp.h"
+#include "daisy_patch.h"
+#include <string>
+
+using namespace daisy;
+using namespace daisysp;
+
+DaisyPatch patch;
+
+static void AudioCallback(float **in, float **out, size_t size)
+{
+    for (size_t i = 0; i < size; i += 2)
+    {
+        for (size_t chn = 0; chn < 4; chn++)
+        {
+            out[chn][i] = 0.f;
+        }
+    }
+}
+
+int main(void)
+{
+    float samplerate;
+    patch.Init(); // Initialize hardware (daisy seed, and patch)
+    samplerate = patch.AudioSampleRate();
+   
+    patch.StartAdc();
+    patch.StartAudio(AudioCallback);
+    while(1) 
+    {
+    }
+}

--- a/patch/Noise/README.md
+++ b/patch/Noise/README.md
@@ -1,0 +1,14 @@
+# Description
+
+
+# Controls
+
+| Control | Description | Comment |
+| --- | --- | --- |
+
+# Diagram
+<img src="https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/Noise/resources/Noise.png" alt="Noise.png" style="width: 100%;"/>
+
+# Code Snippet
+```cpp
+```


### PR DESCRIPTION
White noise with two resonant filters. Currently hardcoded to highpass and lowpass, could add a menu to allow for filter selection, but of course bandpass and bandreject can be patched easily from high and lowpass. 