### PR TITLE
Correct git clone links in top-level README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ First off there are a few ways to clone and initialize the repo (with its submod
 You can do either of the following:
 
 ```
-git clone --recursive https://github.com/Electro-Smith/Daisy_Examples
+git clone --recursive https://github.com/electro-smith/DaisyExamples
 ```
 
 or 
 
 ```
-git clone https://github.com/Electro-Smith/Daisy_Examples
+git clone https://github.com/electro-smith/DaisyExamples
 git submodule update --init
 ```
 


### PR DESCRIPTION
This commit changes the links in the main README to point to the current, correct path to the `DaisyExamples` repository.