### PR TITLE
Minor Fixes for folder Reorg in libdaisy

### DIFF
--- a/petal/GeneralFunctionTest/Makefile
+++ b/petal/GeneralFunctionTest/Makefile
@@ -10,12 +10,14 @@ DAISYSP_DIR = ../../DaisySP
 
 # FatFs
 FATFS_DIR = $(LIBDAISY_DIR)/Middlewares/Third_Party/FatFs/src
-C_INCLUDES = -I$(FATFS_DIR)
 C_SOURCES = \
 	$(FATFS_DIR)/diskio.c \
 	$(FATFS_DIR)/ff.c \
 	$(FATFS_DIR)/ff_gen_drv.c \
 	$(FATFS_DIR)/option/ccsbcs.c \
+
+# FATFS dir contains fatfs itself, libdaisy sys folder contains ffconf 
+C_INCLUDES = -I$(FATFS_DIR) -I$(LIBDAISY_DIR)/src/sys
 
 # Core location, and generic Makefile.
 SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core

--- a/seed/OLED/OLED.cpp
+++ b/seed/OLED/OLED.cpp
@@ -1,7 +1,6 @@
 #include <stdio.h>
 #include <string.h>
 #include "daisy_seed.h"
-#include "hid_oled_display.h"
 
 using namespace daisy;
 

--- a/seed/SDMMC/Makefile
+++ b/seed/SDMMC/Makefile
@@ -10,12 +10,14 @@ DAISYSP_DIR = ../../DaisySP
 
 # FatFs
 FATFS_DIR = $(LIBDAISY_DIR)/Middlewares/Third_Party/FatFs/src
-C_INCLUDES = -I$(FATFS_DIR)
 C_SOURCES = \
 	$(FATFS_DIR)/diskio.c \
 	$(FATFS_DIR)/ff.c \
 	$(FATFS_DIR)/ff_gen_drv.c \
 	$(FATFS_DIR)/option/ccsbcs.c \
+
+# FATFS dir contains fatfs itself, libdaisy sys folder contains ffconf 
+C_INCLUDES = -I$(FATFS_DIR) -I$(LIBDAISY_DIR)/src/sys
 
 # Core location, and generic makefile.
 SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core

--- a/seed/WavPlayer/Makefile
+++ b/seed/WavPlayer/Makefile
@@ -10,12 +10,14 @@ DAISYSP_DIR = ../../DaisySP
 
 # FatFs
 FATFS_DIR = $(LIBDAISY_DIR)/Middlewares/Third_Party/FatFs/src
-C_INCLUDES = -I$(FATFS_DIR)
 C_SOURCES = \
 	$(FATFS_DIR)/diskio.c \
 	$(FATFS_DIR)/ff.c \
 	$(FATFS_DIR)/ff_gen_drv.c \
 	$(FATFS_DIR)/option/ccsbcs.c \
+
+# FATFS dir contains fatfs itself, libdaisy sys folder contains ffconf 
+C_INCLUDES = -I$(FATFS_DIR) -I$(LIBDAISY_DIR)/src/sys
 
 # Core location, and generic makefile.
 SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core


### PR DESCRIPTION
Removed unnecessary include from `seed/oled` example, and added include flag to `Makefile` for SD card examples to be able to properly see the default ffconf in libdaisy.