### PR TITLE
Update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Daisy_Examples
 
-If you are just getting started with Daisy, check out our [Getting Started Wiki page!](https://github.com/electro-smith/DaisyWiki/wiki/1.-Getting-Started)
+If you are just getting started with Daisy, check out our [Getting Started Wiki page!](https://github.com/electro-smith/DaisyWiki/wiki)
 
 This repo is home to a functional pipeline utilizing libDaisy and DaisySP libraries.
 

--- a/pod/ChordMachine/README.md
+++ b/pod/ChordMachine/README.md
@@ -2,10 +2,14 @@
 A simple sine wave chord machine. Cycle through different chord types and inversions.
 
 # Controls
-Turning the left knob changes the root pitch, and therefore shifts the whole chord.  
-Turning the right knob changes the inversion, from 0 through 4.  
-Pressing the encoder resets to the first chord.  
-Rotate the encoder to cycle through different chord types. Led color indicates the chord.
+| Control | Description | Comment |
+| --- | --- | --- |
+| Knob 1 | Root pitch | Shifts the whole chord |
+| Knob 2 | Inversion | 0 – 4 |
+| Encoder | Rotate: Cycle through different chord types<br>Press: Reset to the first chord | |
+| LED | Chord indicator | |
+
+### Chord types
   1. Major triad, Red
   2. Minor triad, Green
   3. Augmented triad, Blue
@@ -16,6 +20,9 @@ Rotate the encoder to cycle through different chord types. Led color indicates t
   8. Minor/Major seven, Yellow
   9. Diminished seven, Pink
   10. Half diminished seven, Light green
+
+# Diagram
+<img src="https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/SynthVoice/resources/SynthVoice.png" alt="Button_schem.png" style="width: 100%;"/>
 
 # Code Snippet
     void UpdateKnobs()

--- a/pod/ChordMachine/README.md
+++ b/pod/ChordMachine/README.md
@@ -21,12 +21,9 @@ A simple sine wave chord machine. Cycle through different chord types and invers
   9. Diminished seven, Pink
   10. Half diminished seven, Light green
 
-# Diagram
-<img src="https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/SynthVoice/resources/SynthVoice.png" alt="Button_schem.png" style="width: 100%;"/>
-
 # Code Snippet
     void UpdateKnobs()
-    {   
+    {
         int freq = (int) p_freq.Process(); 
         int inversion = (int) p_inversion.Process();
         

--- a/pod/MultiEffect/README.md
+++ b/pod/MultiEffect/README.md
@@ -5,13 +5,13 @@ Simple effects for incoming audio. Includes reverb, delay, and downsampling.
 | Control | Description | Comment |
 | --- | --- | --- |
 | Encoder | Mode Select | |
-| LED | Mode Indicate | 1: Red, 2: Green, 3: Purple | 
+| LED | Mode Indicate | 1: Blue, 2: Green, 3: Purple | 
 | Audio In | Effect In | |
 | Audio Out | Effect Out | |
 
 | Control | Mode 1: Reverb | Mode 2: Delay | Mode 3: Bitcrush / Lowpass
 | --- | --- | --- | --- |
-| LED Color | Red | Green | Purple | 
+| LED Color | Blue | Green | Purple | 
 | Knob 1 | Dry/wet | Delay time | LPF cutoff |
 | Knob 2 | Reverb time | Feedback | Downsample |
 

--- a/pod/MultiEffect/README.md
+++ b/pod/MultiEffect/README.md
@@ -4,13 +4,16 @@ Simple effects for incoming audio. Includes reverb, delay, and downsampling.
 # Controls
 | Control | Description | Comment |
 | --- | --- | --- |
-| Mode 1 | Reverb | Knob 1: Dry/wet. Knob 2: Reverb time |
-| Mode 2 | Delay | Knob 1: delay time. Knob 2: Feedback |
-| Mode 3 | Bitcrush / Lowpass | Knob 1: LPF cutoff Knob 2: Downsample |
 | Encoder | Mode Select | |
-| Led | Mode Indicate | 1: Red 2: Green 3: Purple | 
+| LED | Mode Indicate | 1: Red, 2: Green, 3: Purple | 
 | Audio In | Effect In | |
 | Audio Out | Effect Out | |
+
+| Control | Mode 1: Reverb | Mode 2: Delay | Mode 3: Bitcrush / Lowpass
+| --- | --- | --- | --- |
+| LED Color | Red | Green | Purple | 
+| Knob 1 | Dry/wet | Delay time | LPF cutoff |
+| Knob 2 | Reverb time | Feedback | Downsample |
 
 # Diagram
 <img src="https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/MultiEffect/resources/MultiEffect.png" alt="Button_schem.png" style="width: 100%;"/>

--- a/pod/StepSequencer/README.md
+++ b/pod/StepSequencer/README.md
@@ -2,34 +2,42 @@
 Simple 8 step sequencer. Has controls per step for envelope decay, pitch, and step activation.
 
 # Controls
-Edit and play mode, press encoder to switch modes. Edit is multicolored, play is green.  
+Edit and play mode, press encoder to switch modes. Edit is multicolored, play is green.
 
-Edit mode  
-  * Rotate encoder to run through steps.  
-  * Knob one sets decay time.  
-  * Knob two sets pitch. (A pentatonic major)  
-  * Press either button to activate or deactivate a step.  
-  * Led one tells you which step you're on (color).  
-  * Led two is lit if the current step is active.  
-  * When a step is activated, its envelope will cycle. Listen for pitch and envelope shape.  
-  * Button one toggles cycling so you can listen to the step.
-  * Button two toggles step activation. If this is on, the step will play when the sequence runs.
+## Edit mode
+| Control | Description | Comment |
+| --- | --- | --- |
+| Encoder | Rotate: run through steps | |
+| Knob 1 | Set decay time | |
+| Knob 2 | Set pitch | A pentatonic major |
+| Button 1 | Toggle cycling | so you can listen to the step |
+| Button 2 | Activate / deactivate a step | If on, the step will play when the sequence runs |
+| Led 1 | Color: Current step | Colors see below |
+| Led 2 | On/Off: Step active/inactive | |
 
-  * In edit mode the LEDS indicate which step you're on.  
-  * One: Red  
-  * Two: Green  
-  * Three:  Blue  
-  * Four: White  
-  * Five: Purple  
-  * Six: Cyan  
-  * Seven: Gold / Orange  
-  * Eight: Yellow  
+When a step is activated, its envelope will cycle. Listen for pitch and envelope shape.
 
-Play mode  
-  * Knob one controls tempo.  
-  * Knob two controls filter cutoff  
-  * Turning the encoder switches waveform. (Ramp or Square)
-  
+### Step Colors
+| Step | Color |
+| --- | --- |
+| 1 | Red |
+| 2 | Green |
+| 3 | Blue |
+| 4 | White |
+| 5 | Purple |
+| 6 | Cyan |
+| 7 | Gold / Orange |
+| 8 | Yellow |
+
+
+## Play mode
+| Control | Description | Comment |
+| --- | --- | --- |
+| Encoder | Rotate: Waveform | Ramp, Square |
+| Knob 1 | Tempo | |
+| Knob 2 | Filter cutoff |  |
+
+
 # Code Snippet
     void NextSamples(float& sig)
     {
@@ -37,17 +45,17 @@ Play mode
         osc.SetAmp(env_out);
         sig = osc.Process();
         sig = flt.Process(sig);
-        
+
         if (tick.Process() && !edit)
         {
 	    step++;
     	    step %= 8;
     	    if (active[step])
     	    {
-    	        env.Trigger();	   
+    	        env.Trigger();
     	    }
         }
-        
+
         if (active[step])
         {
     	    env.SetTime(ADENV_SEG_DECAY, dec[step]);

--- a/pod/SynthVoice/README.md
+++ b/pod/SynthVoice/README.md
@@ -4,14 +4,20 @@ Simple Synth voice with resonant filter, self cycling envelope, and vibrato cont
 # Controls
 | Control | Description | Comment |
 | --- | --- | --- |
-| Mode 1 | Filter / Freq | Knob 1: Cutoff, Knob 2: Osc. Freq. |
-| Mode 2 | Envelope | Knob 1: Attack Knob 2: Decay |
-| Mode 3 | Vibrato | Knob 1: Rate Knob 2: Depth |
-| Led | Mode Indicate | 1. Blue 2. Green 3. Red |
+| Led | Mode Indicate | 1. Blue, 2. Green, 3. Red |
 | Turn Encoder | Mode Select | |
 | Press Encoder | Waveform Select | |
 | Button 1 | Trigger envelope | |
 | Button 2 | Envelope Cycle | Led 2 lights purple when cycling |
+
+| Control| Mode 1: Filter / Freq | Mode 2: Envelope | Mode 3: Vibrato |
+| --- | --- | --- | --- |
+| LED | Blue | Green | Red |
+| Knob 1 | Cutoff | Attack | Rate |
+| Knob 2 | Osc. Freq. | Decay | Depth |
+
+
+
 
 # Diagram
 <img src="https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/SynthVoice/resources/SynthVoice.png" alt="Button_schem.png" style="width: 100%;"/>


### PR DESCRIPTION
## Content

This updates a few READMEs:
1. In the root README: Removes the `/1.-Getting-Started` part of the link as it doesn't exist anymore and just leads to the "create new page" page. See yourself: https://github.com/electro-smith/DaisyWiki/wiki/1.-Getting-Started
0. In `pod/MultiEffect`: Increases readability of the controls table, and fixes an LED color 
0. In `pod/SynthVoice`: Increases readability of the controls table
0. In `pod/StepSequencer`: Transforms the controls instructions into tables
0. In `pod/ChordMachine`: Transforms the controls instructions into a table