### PR TITLE
Fixes pod examples with backwards buttons

### DIFF
--- a/pod/Looper/Looper.cpp
+++ b/pod/Looper/Looper.cpp
@@ -72,7 +72,7 @@ void ResetBuffer()
 void UpdateButtons()
 {
     //button1 pressed
-    if(pod.button1.RisingEdge())
+    if(pod.button2.RisingEdge())
     {
         if(first && rec)
         {
@@ -87,14 +87,14 @@ void UpdateButtons()
     }
 
     //button1 held
-    if(pod.button1.TimeHeldMs() >= 1000 && res)
+    if(pod.button2.TimeHeldMs() >= 1000 && res)
     {
         ResetBuffer();
 	res = false;
     }
     
     //button2 pressed and not empty buffer
-    if(pod.button2.RisingEdge() && !(!rec && first))
+    if(pod.button1.RisingEdge() && !(!rec && first))
     {
         play = !play;
 	rec = false;

--- a/pod/StepSequencer/StepSequencer.cpp
+++ b/pod/StepSequencer/StepSequencer.cpp
@@ -145,11 +145,11 @@ void UpdateButtons()
 {
   if (edit)
     {
-        if (pod.button1.RisingEdge())
+        if (pod.button2.RisingEdge())
 	{
 	    active[step] = !active[step];
 	}
-	if (pod.button2.RisingEdge())
+	if (pod.button1.RisingEdge())
 	{
 	    editCycle = !editCycle;
 	}

--- a/pod/SynthVoice/SynthVoice.cpp
+++ b/pod/SynthVoice/SynthVoice.cpp
@@ -175,12 +175,12 @@ void UpdateLeds()
 
 void UpdateButtons()
 {
-    if (pod.button2.RisingEdge() || (selfCycle && !ad.IsRunning()))
+    if (pod.button1.RisingEdge() || (selfCycle && !ad.IsRunning()))
     {
   	ad.Trigger();
     }
 
-    if (pod.button1.RisingEdge())
+    if (pod.button2.RisingEdge())
     {
         selfCycle = !selfCycle;
     }


### PR DESCRIPTION
Some pod examples had the buttons mapped backwards to compensate for the backwards defines in libdaisy. 