### PR TITLE
Update/audio api fixes

### DIFF
--- a/field/KeyboardTest/KeyboardTest.cpp
+++ b/field/KeyboardTest/KeyboardTest.cpp
@@ -10,9 +10,9 @@ DaisyField hw;
 
 struct voice
 {
-    void Init()
+    void Init(float samplerate)
     {
-        osc_.Init(DSY_AUDIO_SAMPLE_RATE);
+        osc_.Init(samplerate);
         amp_ = 0.0f;
         osc_.SetAmp(0.7f);
         osc_.SetWaveform(daisysp::Oscillator::WAVE_POLYBLEP_SAW);
@@ -163,16 +163,18 @@ void UpdateLeds(float *knob_vals)
 
 int main(void)
 {
+    float sr;
     hw.Init();
+    sr = hw.AudioSampleRate();
     // Initialize controls.
     octaves = 2;
     for(int i = 0; i < NUM_VOICES; i++)
     {
-        v[i].Init();
+        v[i].Init(sr);
         v[i].set_note((12.0f * octaves) + 24.0f + scale[i]);
     }
 
-    verb.Init(hw.SampleRate());
+    verb.Init(sr);
     verb.SetFeedback(0.94f);
     verb.SetLpFreq(8000.0f);
 

--- a/field/Midi/Midi.cpp
+++ b/field/Midi/Midi.cpp
@@ -210,7 +210,7 @@ int main(void)
     // Init
     float samplerate;
     hw.Init();
-    samplerate = hw.SampleRate();
+    samplerate = hw.AudioSampleRate();
     midi.Init(MidiHandler::INPUT_MODE_UART1, MidiHandler::OUTPUT_MODE_NONE);
     voice_handler.Init(samplerate);
 

--- a/seed/HWTest/HWTest.cpp
+++ b/seed/HWTest/HWTest.cpp
@@ -51,7 +51,6 @@ int main(void)
 		}
 	}
 	dsy_tim_start();
-	dsy_audio_set_callback(DSY_AUDIO_INTERNAL, bad_callback);
-	dsy_audio_start(DSY_AUDIO_INTERNAL);
+    hw.StartAudio(bad_callback);
     while(1) {}
 }

--- a/seed/Ram/Ram.cpp
+++ b/seed/Ram/Ram.cpp
@@ -51,8 +51,7 @@ int main(void)
 		}
 	}
 	dsy_tim_start();
-	dsy_audio_set_callback(DSY_AUDIO_INTERNAL, bad_callback);
-	dsy_audio_start(DSY_AUDIO_INTERNAL);
+    hw.StartAudio(bad_callback);
 	while(1) {}
 }
 


### PR DESCRIPTION
Updates seed/HWTest, seed/Ram, field/KeyboardTest, and field/MIDI to be compliant with the now common API in electro-smith/libdaisy#251

Only changes are `DaisyField::SampleRate()` is now `DaisyField::AudioSampleRate()` to match the rest of the board files' APIs and switching to the DaisySeed audio functions instead of using the old `dsy_audio_foo` functions