### PR TITLE
Fix wiki link by making it an absolute url

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ git submodule update --init
 
 ### Compiling the Source
 
-Once you have the repository and the submodules (libDaisy/DaisySP) properly cloned, and the toolchain installed (for details see the [Daisy Wiki](github.com/electro-smith/DaisyWiki/wiki) for platform specific instructions) it's time to build the libraries, and some examples.
+Once you have the repository and the submodules (libDaisy/DaisySP) properly cloned, and the toolchain installed (for details see the [Daisy Wiki](https://github.com/electro-smith/DaisyWiki/wiki) for platform specific instructions) it's time to build the libraries, and some examples.
 
 To build everything at once, run: `./rebuild_all.sh`
 


### PR DESCRIPTION
Update the wiki link from a relative url to an absolute url, as the existing url takes you to `https://github.com/electro-smith/DaisyExamples/blob/master/github.com/electro-smith/DaisyWiki/wiki` which is a 404.