### PR TITLE
EnvelopeOscillator audio type name update

### DIFF
--- a/patch/EnvelopeOscillator/EnvelopeOscillator.cpp
+++ b/patch/EnvelopeOscillator/EnvelopeOscillator.cpp
@@ -51,7 +51,9 @@ void UpdateControls()
     }
 }
 
-static void AudioCallback(AudioHandle::InputBuffer in, AudioHandle::OutputBuffer out, size_t size)
+static void AudioCallback(AudioHandle::InputBuffer  in,
+                          AudioHandle::OutputBuffer out,
+                          size_t                    size)
 {
     UpdateControls();
 
@@ -76,7 +78,7 @@ void UpdateDisplay()
     patch.display.Fill(false);
 
     std::string str  = "ENVELOPE OSCILLATOR";
-    char *      cstr = &str[0];
+    char*       cstr = &str[0];
     patch.display.SetCursor(minX, minY);
     patch.display.WriteString(cstr, Font_6x8, true);
 


### PR DESCRIPTION
fixed type names for audio callback to resolve the last thing in #184 (mostly due to my merging PRs out of order)