### PR TITLE
Update examples to built in board MidiHandlers

### DIFF
--- a/field/Midi/Midi.cpp
+++ b/field/Midi/Midi.cpp
@@ -5,7 +5,7 @@
 using namespace daisy;
 using namespace daisysp;
 
-DaisyField  hw;
+DaisyField hw;
 
 class Voice
 {

--- a/field/Midi/Midi.cpp
+++ b/field/Midi/Midi.cpp
@@ -6,7 +6,6 @@ using namespace daisy;
 using namespace daisysp;
 
 DaisyField  hw;
-MidiHandler midi;
 
 class Voice
 {
@@ -210,7 +209,6 @@ int main(void)
     float samplerate;
     hw.Init();
     samplerate = hw.AudioSampleRate();
-    midi.Init(MidiHandler::INPUT_MODE_UART1, MidiHandler::OUTPUT_MODE_NONE);
     voice_handler.Init(samplerate);
 
     //display
@@ -220,16 +218,16 @@ int main(void)
     hw.display.Update();
 
     // Start stuff.
-    midi.StartReceive();
+    hw.midi.StartReceive();
     hw.StartAdc();
     hw.StartAudio(AudioCallback);
     for(;;)
     {
-        midi.Listen();
+        hw.midi.Listen();
         // Handle MIDI Events
-        while(midi.HasEvents())
+        while(hw.midi.HasEvents())
         {
-            HandleMidiMessage(midi.PopEvent());
+            HandleMidiMessage(hw.midi.PopEvent());
         }
     }
 }

--- a/patch/Midi/Midi.cpp
+++ b/patch/Midi/Midi.cpp
@@ -5,9 +5,9 @@
 using namespace daisy;
 using namespace daisysp;
 
-DaisyPatch  hw;
-Oscillator  osc;
-Svf         filt;
+DaisyPatch hw;
+Oscillator osc;
+Svf        filt;
 
 void AudioCallback(AudioHandle::InputBuffer  in,
                    AudioHandle::OutputBuffer out,

--- a/patch/Midi/Midi.cpp
+++ b/patch/Midi/Midi.cpp
@@ -6,7 +6,6 @@ using namespace daisy;
 using namespace daisysp;
 
 DaisyPatch  hw;
-MidiHandler midi;
 Oscillator  osc;
 Svf         filt;
 
@@ -72,7 +71,6 @@ int main(void)
     float samplerate;
     hw.Init();
     samplerate = hw.AudioSampleRate();
-    midi.Init(MidiHandler::INPUT_MODE_UART1, MidiHandler::OUTPUT_MODE_NONE);
 
     // Synthesis
     osc.Init(samplerate);
@@ -86,16 +84,16 @@ int main(void)
     hw.display.Update();
 
     // Start stuff.
-    midi.StartReceive();
+    hw.midi.StartReceive();
     hw.StartAdc();
     hw.StartAudio(AudioCallback);
     for(;;)
     {
-        midi.Listen();
+        hw.midi.Listen();
         // Handle MIDI Events
-        while(midi.HasEvents())
+        while(hw.midi.HasEvents())
         {
-            HandleMidiMessage(midi.PopEvent());
+            HandleMidiMessage(hw.midi.PopEvent());
         }
     }
 }

--- a/pod/Midi/Midi.cpp
+++ b/pod/Midi/Midi.cpp
@@ -6,9 +6,9 @@
 using namespace daisy;
 using namespace daisysp;
 
-DaisyPod    hw;
-Oscillator  osc;
-Svf         filt;
+DaisyPod   hw;
+Oscillator osc;
+Svf        filt;
 
 void AudioCallback(AudioHandle::InterleavingInputBuffer  in,
                    AudioHandle::InterleavingOutputBuffer out,

--- a/pod/Midi/Midi.cpp
+++ b/pod/Midi/Midi.cpp
@@ -7,7 +7,6 @@ using namespace daisy;
 using namespace daisysp;
 
 DaisyPod    hw;
-MidiHandler midi;
 Oscillator  osc;
 Svf         filt;
 
@@ -78,7 +77,6 @@ int main(void)
     hw.Init();
     hw.seed.usb_handle.Init(UsbHandle::FS_INTERNAL);
     System::Delay(250);
-    midi.Init(MidiHandler::INPUT_MODE_UART1, MidiHandler::OUTPUT_MODE_NONE);
 
     // Synthesis
     samplerate = hw.AudioSampleRate();
@@ -89,14 +87,14 @@ int main(void)
     // Start stuff.
     hw.StartAdc();
     hw.StartAudio(AudioCallback);
-    midi.StartReceive();
+    hw.midi.StartReceive();
     for(;;)
     {
-        midi.Listen();
+        hw.midi.Listen();
         // Handle MIDI Events
-        while(midi.HasEvents())
+        while(hw.midi.HasEvents())
         {
-            HandleMidiMessage(midi.PopEvent());
+            HandleMidiMessage(hw.midi.PopEvent());
         }
     }
 }


### PR DESCRIPTION
Added a MidiHandler and Init to each breakout board (among other things) [here](https://github.com/electro-smith/libDaisy/pull/350).
This PR will update the three relevant examples to use those new handlers.