### PR TITLE
WIP: Patch/Nimbus: Midi Support

### DIFF
--- a/patch/Nimbus/README.md
+++ b/patch/Nimbus/README.md
@@ -69,3 +69,21 @@ You can also select from four quality / mono stereo modes. These are:
 - 8bit u-law Stereo
 - 8bit u-law Mono
 Refer to the [Clouds Manual](https://mutable-instruments.net/modules/clouds/manual/) section on "Audio Quality".  
+
+#### Midi Channel
+In this Menu you can configure which midi channel Nimbus should listen to.
+
+You can control all paramters via Midi:
+- NoteOn events set the pitch parameter.
+- All other parameters can be adjusted using midi ControlChange messages. 
+
+| CC# | parameter     |
+| --- | ------------- |
+| CC1 | position      |
+| CC2 | size          |
+| CC3 | density       |
+| CC4 | texture       |
+| CC5 | dry_wet       |
+| CC6 | stereo_spread |
+| CC7 | feedback      |
+| CC8 | reverb        |


### PR DESCRIPTION
Hi

I'm working on a feature to control all the parameters in the Nimbus Firmware with midi.

I'm marking this as Work in Progress, as the midi handling in the current libdaisy is a bit buggy.
Never the less, here is a first working draft. It will work as long as there are no Midi RealTime (clock) messages coming in. Otherwise (and that is usually the case when connecting a midi sequencer) the Midi parser in libdaisy has to be patched to ignore the buggy clock messages.
I saw a bit too late that there is a PR https://github.com/electro-smith/libDaisy/pull/350 fixing the Midi parser. I think it makes sense to change this to use the new parser as soon as the mentioned PR is merged.

If you want to test this out in the meantime, here is the midi parser patch:
``` diff
diff --git a/src/hid/midi.cpp b/src/hid/midi.cpp
index 1df5860..7cb4ec4 100644
--- a/src/hid/midi.cpp
+++ b/src/hid/midi.cpp
@@ -77,8 +77,10 @@ void MidiHandler::Parse(uint8_t byte)
     switch(pstate_)
     {
         case ParserEmpty:
+            // ignore single-byte realtime (Clock) messages
+            if (byte == kRealTimeMask) {}
             // check byte for valid Status Byte
-            if(byte & kStatusByteMask)
+            else if(byte & kStatusByteMask)
             {
                 // Get MessageType, and Channel
                 incoming_message_.channel = byte & kChannelMask;
```