### PR TITLE
Fix project create script: Remove file path string concat

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -150,7 +150,7 @@ def create_from_template(destination, board, libs):
     libs = pathlib.Path(os.path.relpath(libs, destination)).as_posix()
     file_path = pathlib.Path(__file__).as_posix().replace('helper.py', '')
 
-    template_dir = file_path + '/utils/Template'
+    template_dir = os.path.join(file_path, 'utils', 'Template')
     copy_project(destination, template_dir)
 
     libdaisy_dir = libs + "/libdaisy/"


### PR DESCRIPTION
I ran into an issue when trying to create a sample project:
```
python ./helper.py create ../lowstepper/lowstepper_daisy_firmware --board seed
creating new project: ../lowstepper/lowstepper_daisy_firmware for platform: seed
copying /utils/Template to new project: ../lowstepper/lowstepper_daisy_firmware
source directory is not valid.
done
```

I noticed that the line above  (`L151 file_path = pathlib.Path(__file__).as_posix().replace('helper.py', '')`) is returning an empty string, I'm not a python programmer and not sure if that is the expected result. However, this can serve as a temporary fix while the above is investigated. It was sufficient to make the documentation [here](https://github.com/electro-smith/DaisyWiki/wiki/How-To:-Create-a-New-Project) work.