### PR TITLE
Torus - build fix for upcoming libDaisy changes

### DIFF
--- a/dist/examples.json
+++ b/dist/examples.json
@@ -1,10 +1,45 @@
 [
     {
-        "name": "bypass",
+        "name": "oscbank",
         "platform": "seed",
-        "filepath": "./dist/seed/bypass.bin",
+        "filepath": "./dist/seed/oscbank.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/bypass/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/oscbank/README.md"
+    },
+    {
+        "name": "clockednoise",
+        "platform": "seed",
+        "filepath": "./dist/seed/clockednoise.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/clockednoise/README.md"
+    },
+    {
+        "name": "comb",
+        "platform": "seed",
+        "filepath": "./dist/seed/comb.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/comb/README.md"
+    },
+    {
+        "name": "autowah",
+        "platform": "seed",
+        "filepath": "./dist/seed/autowah.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/autowah/README.md"
+    },
+    {
+        "name": "biquad",
+        "platform": "seed",
+        "filepath": "./dist/seed/biquad.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/biquad/README.md"
+    },
+    {
+        "name": "synthbassdrum",
+        "platform": "seed",
+        "filepath": "./dist/seed/synthbassdrum.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/synthbassdrum/README.md"
     },
     {
         "name": "Drum",
@@ -14,18 +49,39 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/Drum/README.md"
     },
     {
-        "name": "formantosc",
+        "name": "harmonic_osc",
         "platform": "seed",
-        "filepath": "./dist/seed/formantosc.bin",
+        "filepath": "./dist/seed/harmonic_osc.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/formantosc/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/harmonic_osc/README.md"
     },
     {
-        "name": "allpass",
+        "name": "compressor",
         "platform": "seed",
-        "filepath": "./dist/seed/allpass.bin",
+        "filepath": "./dist/seed/compressor.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/allpass/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/compressor/README.md"
+    },
+    {
+        "name": "QSPI",
+        "platform": "seed",
+        "filepath": "./dist/seed/QSPI.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/QSPI/README.md"
+    },
+    {
+        "name": "reverbsc",
+        "platform": "seed",
+        "filepath": "./dist/seed/reverbsc.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/reverbsc/README.md"
+    },
+    {
+        "name": "Blink",
+        "platform": "seed",
+        "filepath": "./dist/seed/Blink.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/Blink/README.md"
     },
     {
         "name": "hihat",
@@ -35,11 +91,60 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/hihat/README.md"
     },
     {
-        "name": "analogsnaredrum",
+        "name": "svf",
         "platform": "seed",
-        "filepath": "./dist/seed/analogsnaredrum.bin",
+        "filepath": "./dist/seed/svf.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/analogsnaredrum/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/svf/README.md"
+    },
+    {
+        "name": "OLED",
+        "platform": "seed",
+        "filepath": "./dist/seed/OLED.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/OLED/README.md"
+    },
+    {
+        "name": "formantosc",
+        "platform": "seed",
+        "filepath": "./dist/seed/formantosc.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/formantosc/README.md"
+    },
+    {
+        "name": "sampleratereducer",
+        "platform": "seed",
+        "filepath": "./dist/seed/sampleratereducer.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/sampleratereducer/README.md"
+    },
+    {
+        "name": "phaser",
+        "platform": "seed",
+        "filepath": "./dist/seed/phaser.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/phaser/README.md"
+    },
+    {
+        "name": "WavPlayer",
+        "platform": "seed",
+        "filepath": "./dist/seed/WavPlayer.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/WavPlayer/README.md"
+    },
+    {
+        "name": "moogladder",
+        "platform": "seed",
+        "filepath": "./dist/seed/moogladder.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/moogladder/README.md"
+    },
+    {
+        "name": "resonator",
+        "platform": "seed",
+        "filepath": "./dist/seed/resonator.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/resonator/README.md"
     },
     {
         "name": "fir",
@@ -49,11 +154,151 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/fir/README.md"
     },
     {
-        "name": "pitchshifter",
+        "name": "blosc",
         "platform": "seed",
-        "filepath": "./dist/seed/pitchshifter.bin",
+        "filepath": "./dist/seed/blosc.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/pitchshifter/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/blosc/README.md"
+    },
+    {
+        "name": "SDMMC",
+        "platform": "seed",
+        "filepath": "./dist/seed/SDMMC.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/SDMMC/README.md"
+    },
+    {
+        "name": "samplehold",
+        "platform": "seed",
+        "filepath": "./dist/seed/samplehold.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/samplehold/README.md"
+    },
+    {
+        "name": "whitenoise",
+        "platform": "seed",
+        "filepath": "./dist/seed/whitenoise.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/whitenoise/README.md"
+    },
+    {
+        "name": "HWTest",
+        "platform": "seed",
+        "filepath": "./dist/seed/HWTest.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/HWTest/README.md"
+    },
+    {
+        "name": "Knob",
+        "platform": "seed",
+        "filepath": "./dist/seed/Knob.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/Knob/README.md"
+    },
+    {
+        "name": "dcblock",
+        "platform": "seed",
+        "filepath": "./dist/seed/dcblock.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/dcblock/README.md"
+    },
+    {
+        "name": "allpass",
+        "platform": "seed",
+        "filepath": "./dist/seed/allpass.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/allpass/README.md"
+    },
+    {
+        "name": "adenv",
+        "platform": "seed",
+        "filepath": "./dist/seed/adenv.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/adenv/README.md"
+    },
+    {
+        "name": "Logger",
+        "platform": "seed",
+        "filepath": "./dist/seed/Logger.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/Logger/README.md"
+    },
+    {
+        "name": "tone",
+        "platform": "seed",
+        "filepath": "./dist/seed/tone.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/tone/README.md"
+    },
+    {
+        "name": "balance",
+        "platform": "seed",
+        "filepath": "./dist/seed/balance.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/balance/README.md"
+    },
+    {
+        "name": "particle",
+        "platform": "seed",
+        "filepath": "./dist/seed/particle.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/particle/README.md"
+    },
+    {
+        "name": "bypass",
+        "platform": "seed",
+        "filepath": "./dist/seed/bypass.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/bypass/README.md"
+    },
+    {
+        "name": "adsr",
+        "platform": "seed",
+        "filepath": "./dist/seed/adsr.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/adsr/README.md"
+    },
+    {
+        "name": "fm2",
+        "platform": "seed",
+        "filepath": "./dist/seed/fm2.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/fm2/README.md"
+    },
+    {
+        "name": "overdrive",
+        "platform": "seed",
+        "filepath": "./dist/seed/overdrive.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/overdrive/README.md"
+    },
+    {
+        "name": "fractal_noise",
+        "platform": "seed",
+        "filepath": "./dist/seed/fractal_noise.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/fractal_noise/README.md"
+    },
+    {
+        "name": "synthsnaredrum",
+        "platform": "seed",
+        "filepath": "./dist/seed/synthsnaredrum.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/synthsnaredrum/README.md"
+    },
+    {
+        "name": "drip",
+        "platform": "seed",
+        "filepath": "./dist/seed/drip.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/drip/README.md"
+    },
+    {
+        "name": "pluck",
+        "platform": "seed",
+        "filepath": "./dist/seed/pluck.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/pluck/README.md"
     },
     {
         "name": "flanger",
@@ -70,158 +315,11 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/maytrig/README.md"
     },
     {
-        "name": "samplehold",
+        "name": "vosim",
         "platform": "seed",
-        "filepath": "./dist/seed/samplehold.bin",
+        "filepath": "./dist/seed/vosim.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/samplehold/README.md"
-    },
-    {
-        "name": "reverbsc",
-        "platform": "seed",
-        "filepath": "./dist/seed/reverbsc.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/reverbsc/README.md"
-    },
-    {
-        "name": "port",
-        "platform": "seed",
-        "filepath": "./dist/seed/port.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/port/README.md"
-    },
-    {
-        "name": "ReceiveTest",
-        "platform": "seed",
-        "filepath": "./dist/seed/ReceiveTest.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/ReceiveTest/README.md"
-    },
-    {
-        "name": "crossfade",
-        "platform": "seed",
-        "filepath": "./dist/seed/crossfade.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/crossfade/README.md"
-    },
-    {
-        "name": "SDMMC",
-        "platform": "seed",
-        "filepath": "./dist/seed/SDMMC.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/SDMMC/README.md"
-    },
-    {
-        "name": "pluck",
-        "platform": "seed",
-        "filepath": "./dist/seed/pluck.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/pluck/README.md"
-    },
-    {
-        "name": "nlfilt",
-        "platform": "seed",
-        "filepath": "./dist/seed/nlfilt.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/nlfilt/README.md"
-    },
-    {
-        "name": "comb",
-        "platform": "seed",
-        "filepath": "./dist/seed/comb.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/comb/README.md"
-    },
-    {
-        "name": "dust",
-        "platform": "seed",
-        "filepath": "./dist/seed/dust.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/dust/README.md"
-    },
-    {
-        "name": "stringvoice",
-        "platform": "seed",
-        "filepath": "./dist/seed/stringvoice.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/stringvoice/README.md"
-    },
-    {
-        "name": "USB_CDC",
-        "platform": "seed",
-        "filepath": "./dist/seed/USB_CDC.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/USB_CDC/README.md"
-    },
-    {
-        "name": "smooth_random",
-        "platform": "seed",
-        "filepath": "./dist/seed/smooth_random.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/smooth_random/README.md"
-    },
-    {
-        "name": "chorus",
-        "platform": "seed",
-        "filepath": "./dist/seed/chorus.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/chorus/README.md"
-    },
-    {
-        "name": "drip",
-        "platform": "seed",
-        "filepath": "./dist/seed/drip.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/drip/README.md"
-    },
-    {
-        "name": "fm2",
-        "platform": "seed",
-        "filepath": "./dist/seed/fm2.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/fm2/README.md"
-    },
-    {
-        "name": "whitenoise",
-        "platform": "seed",
-        "filepath": "./dist/seed/whitenoise.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/whitenoise/README.md"
-    },
-    {
-        "name": "grainlet",
-        "platform": "seed",
-        "filepath": "./dist/seed/grainlet.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/grainlet/README.md"
-    },
-    {
-        "name": "resonator",
-        "platform": "seed",
-        "filepath": "./dist/seed/resonator.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/resonator/README.md"
-    },
-    {
-        "name": "particle",
-        "platform": "seed",
-        "filepath": "./dist/seed/particle.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/particle/README.md"
-    },
-    {
-        "name": "analogbassdrum",
-        "platform": "seed",
-        "filepath": "./dist/seed/analogbassdrum.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/analogbassdrum/README.md"
-    },
-    {
-        "name": "harmonic_osc",
-        "platform": "seed",
-        "filepath": "./dist/seed/harmonic_osc.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/harmonic_osc/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/vosim/README.md"
     },
     {
         "name": "string",
@@ -231,81 +329,11 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/string/README.md"
     },
     {
-        "name": "jitter",
+        "name": "port",
         "platform": "seed",
-        "filepath": "./dist/seed/jitter.bin",
+        "filepath": "./dist/seed/port.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/jitter/README.md"
-    },
-    {
-        "name": "line",
-        "platform": "seed",
-        "filepath": "./dist/seed/line.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/line/README.md"
-    },
-    {
-        "name": "adenv",
-        "platform": "seed",
-        "filepath": "./dist/seed/adenv.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/adenv/README.md"
-    },
-    {
-        "name": "moogladder",
-        "platform": "seed",
-        "filepath": "./dist/seed/moogladder.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/moogladder/README.md"
-    },
-    {
-        "name": "metro",
-        "platform": "seed",
-        "filepath": "./dist/seed/metro.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/metro/README.md"
-    },
-    {
-        "name": "biquad",
-        "platform": "seed",
-        "filepath": "./dist/seed/biquad.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/biquad/README.md"
-    },
-    {
-        "name": "decimator",
-        "platform": "seed",
-        "filepath": "./dist/seed/decimator.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/decimator/README.md"
-    },
-    {
-        "name": "QSPI",
-        "platform": "seed",
-        "filepath": "./dist/seed/QSPI.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/QSPI/README.md"
-    },
-    {
-        "name": "varisaw",
-        "platform": "seed",
-        "filepath": "./dist/seed/varisaw.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/varisaw/README.md"
-    },
-    {
-        "name": "OLED",
-        "platform": "seed",
-        "filepath": "./dist/seed/OLED.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/OLED/README.md"
-    },
-    {
-        "name": "WavPlayer",
-        "platform": "seed",
-        "filepath": "./dist/seed/WavPlayer.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/WavPlayer/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/port/README.md"
     },
     {
         "name": "faustnoise",
@@ -315,137 +343,25 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/faustnoise/README.md"
     },
     {
-        "name": "oscbank",
+        "name": "nlfilt",
         "platform": "seed",
-        "filepath": "./dist/seed/oscbank.bin",
+        "filepath": "./dist/seed/nlfilt.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/oscbank/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/nlfilt/README.md"
     },
     {
-        "name": "adsr",
+        "name": "chorus",
         "platform": "seed",
-        "filepath": "./dist/seed/adsr.bin",
+        "filepath": "./dist/seed/chorus.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/adsr/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/chorus/README.md"
     },
     {
-        "name": "fractal_noise",
+        "name": "atone",
         "platform": "seed",
-        "filepath": "./dist/seed/fractal_noise.bin",
+        "filepath": "./dist/seed/atone.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/fractal_noise/README.md"
-    },
-    {
-        "name": "Knob",
-        "platform": "seed",
-        "filepath": "./dist/seed/Knob.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/Knob/README.md"
-    },
-    {
-        "name": "blosc",
-        "platform": "seed",
-        "filepath": "./dist/seed/blosc.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/blosc/README.md"
-    },
-    {
-        "name": "phasor",
-        "platform": "seed",
-        "filepath": "./dist/seed/phasor.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/phasor/README.md"
-    },
-    {
-        "name": "oscillator",
-        "platform": "seed",
-        "filepath": "./dist/seed/oscillator.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/oscillator/README.md"
-    },
-    {
-        "name": "svf",
-        "platform": "seed",
-        "filepath": "./dist/seed/svf.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/svf/README.md"
-    },
-    {
-        "name": "balance",
-        "platform": "seed",
-        "filepath": "./dist/seed/balance.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/balance/README.md"
-    },
-    {
-        "name": "dcblock",
-        "platform": "seed",
-        "filepath": "./dist/seed/dcblock.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/dcblock/README.md"
-    },
-    {
-        "name": "variableshapeosc",
-        "platform": "seed",
-        "filepath": "./dist/seed/variableshapeosc.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/variableshapeosc/README.md"
-    },
-    {
-        "name": "vosim",
-        "platform": "seed",
-        "filepath": "./dist/seed/vosim.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/vosim/README.md"
-    },
-    {
-        "name": "Blink",
-        "platform": "seed",
-        "filepath": "./dist/seed/Blink.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/Blink/README.md"
-    },
-    {
-        "name": "tremolo",
-        "platform": "seed",
-        "filepath": "./dist/seed/tremolo.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/tremolo/README.md"
-    },
-    {
-        "name": "synthbassdrum",
-        "platform": "seed",
-        "filepath": "./dist/seed/synthbassdrum.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/synthbassdrum/README.md"
-    },
-    {
-        "name": "autowah",
-        "platform": "seed",
-        "filepath": "./dist/seed/autowah.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/autowah/README.md"
-    },
-    {
-        "name": "modalvoice",
-        "platform": "seed",
-        "filepath": "./dist/seed/modalvoice.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/modalvoice/README.md"
-    },
-    {
-        "name": "delayline",
-        "platform": "seed",
-        "filepath": "./dist/seed/delayline.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/delayline/README.md"
-    },
-    {
-        "name": "sampleratereducer",
-        "platform": "seed",
-        "filepath": "./dist/seed/sampleratereducer.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/sampleratereducer/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/atone/README.md"
     },
     {
         "name": "zoscillator",
@@ -462,32 +378,11 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/LCD_HD44780/README.md"
     },
     {
-        "name": "tone",
-        "platform": "seed",
-        "filepath": "./dist/seed/tone.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/tone/README.md"
-    },
-    {
         "name": "Ram",
         "platform": "seed",
         "filepath": "./dist/seed/Ram.bin",
         "description": "no desc available yet",
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/Ram/README.md"
-    },
-    {
-        "name": "compressor",
-        "platform": "seed",
-        "filepath": "./dist/seed/compressor.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/compressor/README.md"
-    },
-    {
-        "name": "overdrive",
-        "platform": "seed",
-        "filepath": "./dist/seed/overdrive.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/overdrive/README.md"
     },
     {
         "name": "Button",
@@ -497,18 +392,109 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/Button/README.md"
     },
     {
-        "name": "HWTest",
+        "name": "bitcrush",
         "platform": "seed",
-        "filepath": "./dist/seed/HWTest.bin",
+        "filepath": "./dist/seed/bitcrush.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/HWTest/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/bitcrush/README.md"
     },
     {
-        "name": "synthsnaredrum",
+        "name": "dust",
         "platform": "seed",
-        "filepath": "./dist/seed/synthsnaredrum.bin",
+        "filepath": "./dist/seed/dust.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/synthsnaredrum/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/dust/README.md"
+    },
+    {
+        "name": "phasor",
+        "platform": "seed",
+        "filepath": "./dist/seed/phasor.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/phasor/README.md"
+    },
+    {
+        "name": "metro",
+        "platform": "seed",
+        "filepath": "./dist/seed/metro.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/metro/README.md"
+    },
+    {
+        "name": "USB_CDC",
+        "platform": "seed",
+        "filepath": "./dist/seed/USB_CDC.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/USB_CDC/README.md"
+    },
+    {
+        "name": "crossfade",
+        "platform": "seed",
+        "filepath": "./dist/seed/crossfade.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/crossfade/README.md"
+    },
+    {
+        "name": "jitter",
+        "platform": "seed",
+        "filepath": "./dist/seed/jitter.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/jitter/README.md"
+    },
+    {
+        "name": "grainlet",
+        "platform": "seed",
+        "filepath": "./dist/seed/grainlet.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/grainlet/README.md"
+    },
+    {
+        "name": "delayline",
+        "platform": "seed",
+        "filepath": "./dist/seed/delayline.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/delayline/README.md"
+    },
+    {
+        "name": "ReceiveTest",
+        "platform": "seed",
+        "filepath": "./dist/seed/ReceiveTest.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/ReceiveTest/README.md"
+    },
+    {
+        "name": "line",
+        "platform": "seed",
+        "filepath": "./dist/seed/line.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/line/README.md"
+    },
+    {
+        "name": "oscillator",
+        "platform": "seed",
+        "filepath": "./dist/seed/oscillator.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/oscillator/README.md"
+    },
+    {
+        "name": "decimator",
+        "platform": "seed",
+        "filepath": "./dist/seed/decimator.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/decimator/README.md"
+    },
+    {
+        "name": "variableshapeosc",
+        "platform": "seed",
+        "filepath": "./dist/seed/variableshapeosc.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/variableshapeosc/README.md"
+    },
+    {
+        "name": "varisaw",
+        "platform": "seed",
+        "filepath": "./dist/seed/varisaw.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/varisaw/README.md"
     },
     {
         "name": "Osc",
@@ -518,67 +504,53 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/Osc/README.md"
     },
     {
-        "name": "phaser",
+        "name": "modalvoice",
         "platform": "seed",
-        "filepath": "./dist/seed/phaser.bin",
+        "filepath": "./dist/seed/modalvoice.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/phaser/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/modalvoice/README.md"
     },
     {
-        "name": "clockednoise",
+        "name": "pitchshifter",
         "platform": "seed",
-        "filepath": "./dist/seed/clockednoise.bin",
+        "filepath": "./dist/seed/pitchshifter.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/clockednoise/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/pitchshifter/README.md"
     },
     {
-        "name": "Logger",
+        "name": "stringvoice",
         "platform": "seed",
-        "filepath": "./dist/seed/Logger.bin",
+        "filepath": "./dist/seed/stringvoice.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/Logger/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/stringvoice/README.md"
     },
     {
-        "name": "bitcrush",
+        "name": "tremolo",
         "platform": "seed",
-        "filepath": "./dist/seed/bitcrush.bin",
+        "filepath": "./dist/seed/tremolo.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/bitcrush/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/tremolo/README.md"
     },
     {
-        "name": "atone",
+        "name": "analogsnaredrum",
         "platform": "seed",
-        "filepath": "./dist/seed/atone.bin",
+        "filepath": "./dist/seed/analogsnaredrum.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/atone/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/analogsnaredrum/README.md"
     },
     {
-        "name": "EuclideanDrums",
-        "platform": "pod",
-        "filepath": "./dist/pod/EuclideanDrums.bin",
+        "name": "analogbassdrum",
+        "platform": "seed",
+        "filepath": "./dist/seed/analogbassdrum.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/EuclideanDrums/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/analogbassdrum/README.md"
     },
     {
-        "name": "MusicBox",
-        "platform": "pod",
-        "filepath": "./dist/pod/MusicBox.bin",
+        "name": "smooth_random",
+        "platform": "seed",
+        "filepath": "./dist/seed/smooth_random.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/MusicBox/README.md"
-    },
-    {
-        "name": "Midi",
-        "platform": "pod",
-        "filepath": "./dist/pod/Midi.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/Midi/README.md"
-    },
-    {
-        "name": "ChordMachine",
-        "platform": "pod",
-        "filepath": "./dist/pod/ChordMachine.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/ChordMachine/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/smooth_random/README.md"
     },
     {
         "name": "SimpleButton",
@@ -586,27 +558,6 @@
         "filepath": "./dist/pod/SimpleButton.bin",
         "description": "no desc available yet",
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/SimpleButton/README.md"
-    },
-    {
-        "name": "StepSequencer",
-        "platform": "pod",
-        "filepath": "./dist/pod/StepSequencer.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/StepSequencer/README.md"
-    },
-    {
-        "name": "SimpleLed",
-        "platform": "pod",
-        "filepath": "./dist/pod/SimpleLed.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/SimpleLed/README.md"
-    },
-    {
-        "name": "SimpleOscillator",
-        "platform": "pod",
-        "filepath": "./dist/pod/SimpleOscillator.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/SimpleOscillator/README.md"
     },
     {
         "name": "MultiEffect",
@@ -623,6 +574,41 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/SynthVoice/README.md"
     },
     {
+        "name": "ChordMachine",
+        "platform": "pod",
+        "filepath": "./dist/pod/ChordMachine.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/ChordMachine/README.md"
+    },
+    {
+        "name": "SimpleLed",
+        "platform": "pod",
+        "filepath": "./dist/pod/SimpleLed.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/SimpleLed/README.md"
+    },
+    {
+        "name": "MusicBox",
+        "platform": "pod",
+        "filepath": "./dist/pod/MusicBox.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/MusicBox/README.md"
+    },
+    {
+        "name": "StepSequencer",
+        "platform": "pod",
+        "filepath": "./dist/pod/StepSequencer.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/StepSequencer/README.md"
+    },
+    {
+        "name": "Midi",
+        "platform": "pod",
+        "filepath": "./dist/pod/Midi.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/Midi/README.md"
+    },
+    {
         "name": "Encoder",
         "platform": "pod",
         "filepath": "./dist/pod/Encoder.bin",
@@ -637,39 +623,18 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/Looper/README.md"
     },
     {
-        "name": "flanger",
-        "platform": "petal",
-        "filepath": "./dist/petal/flanger.bin",
+        "name": "EuclideanDrums",
+        "platform": "pod",
+        "filepath": "./dist/pod/EuclideanDrums.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/flanger/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/EuclideanDrums/README.md"
     },
     {
-        "name": "chorus",
-        "platform": "petal",
-        "filepath": "./dist/petal/chorus.bin",
+        "name": "SimpleOscillator",
+        "platform": "pod",
+        "filepath": "./dist/pod/SimpleOscillator.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/chorus/README.md"
-    },
-    {
-        "name": "Verb",
-        "platform": "petal",
-        "filepath": "./dist/petal/Verb.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/Verb/README.md"
-    },
-    {
-        "name": "CombFilter",
-        "platform": "petal",
-        "filepath": "./dist/petal/CombFilter.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/CombFilter/README.md"
-    },
-    {
-        "name": "FilterBank",
-        "platform": "petal",
-        "filepath": "./dist/petal/FilterBank.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/FilterBank/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/SimpleOscillator/README.md"
     },
     {
         "name": "MultiEffect",
@@ -677,27 +642,6 @@
         "filepath": "./dist/petal/MultiEffect.bin",
         "description": "no desc available yet",
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/MultiEffect/README.md"
-    },
-    {
-        "name": "tremolo",
-        "platform": "petal",
-        "filepath": "./dist/petal/tremolo.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/tremolo/README.md"
-    },
-    {
-        "name": "MultiDelay",
-        "platform": "petal",
-        "filepath": "./dist/petal/MultiDelay.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/MultiDelay/README.md"
-    },
-    {
-        "name": "Distortion",
-        "platform": "petal",
-        "filepath": "./dist/petal/Distortion.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/Distortion/README.md"
     },
     {
         "name": "phaser",
@@ -714,6 +658,34 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/GeneralFunctionTest/README.md"
     },
     {
+        "name": "flanger",
+        "platform": "petal",
+        "filepath": "./dist/petal/flanger.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/flanger/README.md"
+    },
+    {
+        "name": "Verb",
+        "platform": "petal",
+        "filepath": "./dist/petal/Verb.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/Verb/README.md"
+    },
+    {
+        "name": "chorus",
+        "platform": "petal",
+        "filepath": "./dist/petal/chorus.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/chorus/README.md"
+    },
+    {
+        "name": "CombFilter",
+        "platform": "petal",
+        "filepath": "./dist/petal/CombFilter.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/CombFilter/README.md"
+    },
+    {
         "name": "Looper",
         "platform": "petal",
         "filepath": "./dist/petal/Looper.bin",
@@ -721,25 +693,32 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/Looper/README.md"
     },
     {
-        "name": "QuadEnvelope",
-        "platform": "patch",
-        "filepath": "./dist/patch/QuadEnvelope.bin",
+        "name": "FilterBank",
+        "platform": "petal",
+        "filepath": "./dist/petal/FilterBank.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/QuadEnvelope/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/FilterBank/README.md"
     },
     {
-        "name": "QuadMixer",
-        "platform": "patch",
-        "filepath": "./dist/patch/QuadMixer.bin",
+        "name": "Distortion",
+        "platform": "petal",
+        "filepath": "./dist/petal/Distortion.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/QuadMixer/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/Distortion/README.md"
     },
     {
-        "name": "Torus",
-        "platform": "patch",
-        "filepath": "./dist/patch/Torus.bin",
+        "name": "MultiDelay",
+        "platform": "petal",
+        "filepath": "./dist/petal/MultiDelay.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/Torus/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/MultiDelay/README.md"
+    },
+    {
+        "name": "tremolo",
+        "platform": "petal",
+        "filepath": "./dist/petal/tremolo.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/tremolo/README.md"
     },
     {
         "name": "vco",
@@ -749,81 +728,11 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/vco/README.md"
     },
     {
-        "name": "PluckEcho",
+        "name": "SampleAndHold",
         "platform": "patch",
-        "filepath": "./dist/patch/PluckEcho.bin",
+        "filepath": "./dist/patch/SampleAndHold.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/PluckEcho/README.md"
-    },
-    {
-        "name": "SequentialSwitch",
-        "platform": "patch",
-        "filepath": "./dist/patch/SequentialSwitch.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/SequentialSwitch/README.md"
-    },
-    {
-        "name": "Midi",
-        "platform": "patch",
-        "filepath": "./dist/patch/Midi.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/Midi/README.md"
-    },
-    {
-        "name": "PolyOsc",
-        "platform": "patch",
-        "filepath": "./dist/patch/PolyOsc.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/PolyOsc/README.md"
-    },
-    {
-        "name": "lfo",
-        "platform": "patch",
-        "filepath": "./dist/patch/lfo.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/lfo/README.md"
-    },
-    {
-        "name": "QuadraphonicMixer",
-        "platform": "patch",
-        "filepath": "./dist/patch/QuadraphonicMixer.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/QuadraphonicMixer/README.md"
-    },
-    {
-        "name": "verb",
-        "platform": "patch",
-        "filepath": "./dist/patch/verb.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/verb/README.md"
-    },
-    {
-        "name": "FilterBank",
-        "platform": "patch",
-        "filepath": "./dist/patch/FilterBank.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/FilterBank/README.md"
-    },
-    {
-        "name": "Noise",
-        "platform": "patch",
-        "filepath": "./dist/patch/Noise.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/Noise/README.md"
-    },
-    {
-        "name": "Nimbus",
-        "platform": "patch",
-        "filepath": "./dist/patch/Nimbus.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/Nimbus/README.md"
-    },
-    {
-        "name": "Sequencer",
-        "platform": "patch",
-        "filepath": "./dist/patch/Sequencer.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/Sequencer/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/SampleAndHold/README.md"
     },
     {
         "name": "logic",
@@ -833,6 +742,76 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/logic/README.md"
     },
     {
+        "name": "QuadraphonicMixer",
+        "platform": "patch",
+        "filepath": "./dist/patch/QuadraphonicMixer.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/QuadraphonicMixer/README.md"
+    },
+    {
+        "name": "Torus",
+        "platform": "patch",
+        "filepath": "./dist/patch/Torus.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/Torus/README.md"
+    },
+    {
+        "name": "Noise",
+        "platform": "patch",
+        "filepath": "./dist/patch/Noise.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/Noise/README.md"
+    },
+    {
+        "name": "PluckEcho",
+        "platform": "patch",
+        "filepath": "./dist/patch/PluckEcho.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/PluckEcho/README.md"
+    },
+    {
+        "name": "PolyOsc",
+        "platform": "patch",
+        "filepath": "./dist/patch/PolyOsc.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/PolyOsc/README.md"
+    },
+    {
+        "name": "QuadEnvelope",
+        "platform": "patch",
+        "filepath": "./dist/patch/QuadEnvelope.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/QuadEnvelope/README.md"
+    },
+    {
+        "name": "Sequencer",
+        "platform": "patch",
+        "filepath": "./dist/patch/Sequencer.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/Sequencer/README.md"
+    },
+    {
+        "name": "SequentialSwitch",
+        "platform": "patch",
+        "filepath": "./dist/patch/SequentialSwitch.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/SequentialSwitch/README.md"
+    },
+    {
+        "name": "QuadMixer",
+        "platform": "patch",
+        "filepath": "./dist/patch/QuadMixer.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/QuadMixer/README.md"
+    },
+    {
+        "name": "Nimbus",
+        "platform": "patch",
+        "filepath": "./dist/patch/Nimbus.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/Nimbus/README.md"
+    },
+    {
         "name": "Compressor",
         "platform": "patch",
         "filepath": "./dist/patch/Compressor.bin",
@@ -840,18 +819,11 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/Compressor/README.md"
     },
     {
-        "name": "MultiDelay",
+        "name": "Midi",
         "platform": "patch",
-        "filepath": "./dist/patch/MultiDelay.bin",
+        "filepath": "./dist/patch/Midi.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/MultiDelay/README.md"
-    },
-    {
-        "name": "SampleAndHold",
-        "platform": "patch",
-        "filepath": "./dist/patch/SampleAndHold.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/SampleAndHold/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/Midi/README.md"
     },
     {
         "name": "Svf",
@@ -861,6 +833,13 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/Svf/README.md"
     },
     {
+        "name": "FilterBank",
+        "platform": "patch",
+        "filepath": "./dist/patch/FilterBank.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/FilterBank/README.md"
+    },
+    {
         "name": "EnvelopeOscillator",
         "platform": "patch",
         "filepath": "./dist/patch/EnvelopeOscillator.bin",
@@ -868,32 +847,32 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/EnvelopeOscillator/README.md"
     },
     {
-        "name": "flanger",
-        "platform": "field",
-        "filepath": "./dist/field/flanger.bin",
+        "name": "lfo",
+        "platform": "patch",
+        "filepath": "./dist/patch/lfo.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/field/flanger/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/lfo/README.md"
     },
     {
-        "name": "stringvoice",
-        "platform": "field",
-        "filepath": "./dist/field/stringvoice.bin",
+        "name": "MultiDelay",
+        "platform": "patch",
+        "filepath": "./dist/patch/MultiDelay.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/field/stringvoice/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/MultiDelay/README.md"
     },
     {
-        "name": "chorus",
-        "platform": "field",
-        "filepath": "./dist/field/chorus.bin",
+        "name": "verb",
+        "platform": "patch",
+        "filepath": "./dist/patch/verb.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/field/chorus/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/verb/README.md"
     },
     {
-        "name": "Midi",
+        "name": "phaser",
         "platform": "field",
-        "filepath": "./dist/field/Midi.bin",
+        "filepath": "./dist/field/phaser.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/field/Midi/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/field/phaser/README.md"
     },
     {
         "name": "KeyboardTest",
@@ -910,6 +889,27 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/field/Nimbus/README.md"
     },
     {
+        "name": "flanger",
+        "platform": "field",
+        "filepath": "./dist/field/flanger.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/field/flanger/README.md"
+    },
+    {
+        "name": "Midi",
+        "platform": "field",
+        "filepath": "./dist/field/Midi.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/field/Midi/README.md"
+    },
+    {
+        "name": "chorus",
+        "platform": "field",
+        "filepath": "./dist/field/chorus.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/field/chorus/README.md"
+    },
+    {
         "name": "modalvoice",
         "platform": "field",
         "filepath": "./dist/field/modalvoice.bin",
@@ -917,11 +917,11 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/field/modalvoice/README.md"
     },
     {
-        "name": "phaser",
+        "name": "stringvoice",
         "platform": "field",
-        "filepath": "./dist/field/phaser.bin",
+        "filepath": "./dist/field/stringvoice.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/field/phaser/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/field/stringvoice/README.md"
     },
     {
         "name": "Decimator",
@@ -945,11 +945,25 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/HardwareTest/README.md"
     },
     {
+        "name": "ReverbExample",
+        "platform": "patch_sm",
+        "filepath": "./dist/patch_sm/ReverbExample.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/ReverbExample/README.md"
+    },
+    {
         "name": "TripleSaw",
         "platform": "patch_sm",
         "filepath": "./dist/patch_sm/TripleSaw.bin",
         "description": "no desc available yet",
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/TripleSaw/README.md"
+    },
+    {
+        "name": "Looper",
+        "platform": "patch_sm",
+        "filepath": "./dist/patch_sm/Looper.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/Looper/README.md"
     },
     {
         "name": "RandomCvExample",
@@ -971,19 +985,5 @@
         "filepath": "./dist/patch_sm/SimpleOscillator.bin",
         "description": "no desc available yet",
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/SimpleOscillator/README.md"
-    },
-    {
-        "name": "ReverbExample",
-        "platform": "patch_sm",
-        "filepath": "./dist/patch_sm/ReverbExample.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/ReverbExample/README.md"
-    },
-    {
-        "name": "Looper",
-        "platform": "patch_sm",
-        "filepath": "./dist/patch_sm/Looper.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/Looper/README.md"
     }
 ]

--- a/patch/Torus/Makefile
+++ b/patch/Torus/Makefile
@@ -34,7 +34,7 @@ include $(SYSTEM_FILES_DIR)/Makefile
 
 
 ### Need to override all to get support for .cc files
-# all: $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET).bin
+all: $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET).bin
 
 #######################################
 # build the application
@@ -46,7 +46,7 @@ OBJECTS += $(addprefix $(BUILD_DIR)/,$(notdir $(CPP_SOURCES:.cpp=.o)))
 vpath %.cpp $(sort $(dir $(CPP_SOURCES)))
 OBJECTS += $(addprefix $(BUILD_DIR)/,$(notdir $(CC_SOURCES:.cc=.o)))
 vpath %.cc $(sort $(dir $(CC_SOURCES)))
-# # list of ASM program objects
+# list of ASM program objects
 OBJECTS += $(addprefix $(BUILD_DIR)/,$(notdir $(ASM_SOURCES:.s=.o)))
 vpath %.s $(sort $(dir $(ASM_SOURCES)))
 

--- a/patch/Torus/Makefile
+++ b/patch/Torus/Makefile
@@ -14,18 +14,14 @@ dsp/string.cpp \
 dsp/string_synth_part.cpp \
 resources.cpp \
 
-CC_SOURCES = $(STMLIB_DIR)/dsp/units.cc \
+CC_SOURCES += $(STMLIB_DIR)/dsp/units.cc \
 $(STMLIB_DIR)/utils/random.cc \
 cv_scaler.cc \
 
 C_INCLUDES += \
 -I. \
--Idsp \
--Idsp/fx \
--Idrivers \
--Ibootloader \
 -Iresources \
--I../../ \
+-I../..
 
 # Can't actually add to CFLAGS.. due to libDaisy stuff
 # silences warning from stmlib JOIN macros
@@ -38,7 +34,7 @@ include $(SYSTEM_FILES_DIR)/Makefile
 
 
 ### Need to override all to get support for .cc files
-all: $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET).bin
+# all: $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET).bin
 
 #######################################
 # build the application
@@ -50,7 +46,7 @@ OBJECTS += $(addprefix $(BUILD_DIR)/,$(notdir $(CPP_SOURCES:.cpp=.o)))
 vpath %.cpp $(sort $(dir $(CPP_SOURCES)))
 OBJECTS += $(addprefix $(BUILD_DIR)/,$(notdir $(CC_SOURCES:.cc=.o)))
 vpath %.cc $(sort $(dir $(CC_SOURCES)))
-# list of ASM program objects
+# # list of ASM program objects
 OBJECTS += $(addprefix $(BUILD_DIR)/,$(notdir $(ASM_SOURCES:.s=.o)))
 vpath %.s $(sort $(dir $(ASM_SOURCES)))
 


### PR DESCRIPTION
fixed include paths that caused conflict with latest libDaisy.

One of the new libDaisy header files includes cstring, and the compiler didn't like that `dsp/string.h` was in the search path when trying to compile this with that version of libDaisy