### PR TITLE
Minor build script fixes

### DIFF
--- a/ci/build_examples.py
+++ b/ci/build_examples.py
@@ -34,7 +34,7 @@ for dir in dirs_to_search:
     for ex in example_dirs:
         dest = os.path.join(cwd, ex)
         os.chdir(dest)
-        print("Building: {}".format(ex))
+        os.system("echo Building: {}".format(ex))
         exit_code = os.system('make -s clean')
         exit_code = os.system('make -s')
         if exit_code != 0:

--- a/rebuild_all.sh
+++ b/rebuild_all.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ./ci/build_libs.sh
-./ci/build_examples.sh
+./ci/build_examples.py
 
 echo "finished"
 


### PR DESCRIPTION
fixed wrong script callout in rebuild all, and fixed printing in new build script to use echo instead of python print.

The python print function was working, but it waited until all system calls were done before writing everything to stdout. Which makes troubleshooting build issues a bit of a pain.