### PR TITLE
Helper script - making VisualGDB support optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,4 +127,5 @@ bin/
 .visualgdb
 VisualGDBCache
 vs/*.log
+MyProjects/
 

--- a/helper.py
+++ b/helper.py
@@ -322,7 +322,7 @@ def run():
                         example_dirs.append(root)
                 for ex in example_dirs:
                     try:
-                        update_project(ex, args.include_vgdb)
+                        update_project(ex, include_vs=args.include_vgdb)
                     except Exception as e:
                         print('Unable to update example: {}'.format(ex))
                         print(e)

--- a/helper.py
+++ b/helper.py
@@ -322,7 +322,7 @@ def run():
                         example_dirs.append(root)
                 for ex in example_dirs:
                     try:
-                        update_project(ex, include_vs=args.include_vgdb)
+                        update_project(ex, args.libs, args.include_vgdb)
                     except Exception as e:
                         print('Unable to update example: {}'.format(ex))
                         print(e)

--- a/utils/Template/.vscode/c_cpp_properties.json
+++ b/utils/Template/.vscode/c_cpp_properties.json
@@ -11,8 +11,8 @@
       ],
       "includePath": [
         "${workspaceFolder}/**",
-        "@LIBDAISY_DIR@/**",
-        "@DAISYSP_DIR@/**"
+        "${workspaceFolder}/@LIBDAISY_DIR@/**",
+        "${workspaceFolder}/@DAISYSP_DIR@/**"
       ],
       "name": "Win32",
       "windowsSdkVersion": "10.0.17763.0"
@@ -28,8 +28,8 @@
       ],
       "includePath": [
         "${workspaceFolder}/**",
-        "@LIBDAISY_DIR@/**",
-        "@DAISYSP_DIR@/**"
+        "${workspaceFolder}/@LIBDAISY_DIR@/**",
+        "${workspaceFolder}/@DAISYSP_DIR@/**"
       ],
       "name": "macOS"
     }

--- a/utils/Template/.vscode/tasks.json
+++ b/utils/Template/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "@LIBDAISY_DIR@"
+        "cwd": "${wworkspaceFolder}/@LIBDAISY_DIR@"
       },
       "problemMatcher": [
         "$gcc"
@@ -94,7 +94,7 @@
       "command": "make",
       "label": "build_daisysp",
       "options": {
-        "cwd": "@DAISYSP_DIR@"
+        "cwd": "${workspaceFolder}/@DAISYSP_DIR@"
       },
       "problemMatcher": [
         "$gcc"


### PR DESCRIPTION
This update fixes a bug with the existing update (all) command in helper.py, it also makes the copying/updating/creation of Visual Studio+VisualGDB files optional, and non-default.

Also, since `MyProjects/` is called out as the directory for users to try things in the video tutorials and guides, I've added it to the gitignore so that it doesn't have to be manually avoided when contributing new examples back to the community.