### PR TITLE
Fix libDaisy capitalization throughout repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "libdaisy"]
-	path = libdaisy
-	url = https://github.com/electro-smith/libDaisy
-	branch = master
 [submodule "DaisySP"]
 	path = DaisySP
 	url = https://github.com/electro-smith/DaisySP
@@ -9,3 +5,6 @@
 [submodule "stmlib"]
 	path = stmlib
 	url = https://github.com/pichenettes/stmlib
+[submodule "libDaisy"]
+	path = libDaisy
+	url = https://github.com/electro-smith/libDaisy

--- a/ci/build_libs.sh
+++ b/ci/build_libs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 START_DIR=$PWD
-LIBDAISY_DIR=$PWD/libdaisy
+LIBDAISY_DIR=$PWD/libDaisy
 DAISYSP_DIR=$PWD/DaisySP
 
 echo "building libDaisy . . ."

--- a/dist/examples.json
+++ b/dist/examples.json
@@ -1,164 +1,17 @@
 [
     {
-        "name": "QuadEnvelope",
-        "platform": "patch",
-        "filepath": "./dist/patch/QuadEnvelope.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/QuadEnvelope/README.md"
-    },
-    {
-        "name": "SequentialSwitch",
-        "platform": "patch",
-        "filepath": "./dist/patch/SequentialSwitch.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/SequentialSwitch/README.md"
-    },
-    {
-        "name": "EnvelopeOscillator",
-        "platform": "patch",
-        "filepath": "./dist/patch/EnvelopeOscillator.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/EnvelopeOscillator/README.md"
-    },
-    {
-        "name": "Nimbus",
-        "platform": "patch",
-        "filepath": "./dist/patch/Nimbus.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/Nimbus/README.md"
-    },
-    {
-        "name": "QuadMixer",
-        "platform": "patch",
-        "filepath": "./dist/patch/QuadMixer.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/QuadMixer/README.md"
-    },
-    {
-        "name": "QuadraphonicMixer",
-        "platform": "patch",
-        "filepath": "./dist/patch/QuadraphonicMixer.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/QuadraphonicMixer/README.md"
-    },
-    {
-        "name": "PolyOsc",
-        "platform": "patch",
-        "filepath": "./dist/patch/PolyOsc.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/PolyOsc/README.md"
-    },
-    {
-        "name": "Noise",
-        "platform": "patch",
-        "filepath": "./dist/patch/Noise.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/Noise/README.md"
-    },
-    {
-        "name": "vco",
-        "platform": "patch",
-        "filepath": "./dist/patch/vco.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/vco/README.md"
-    },
-    {
-        "name": "MultiDelay",
-        "platform": "patch",
-        "filepath": "./dist/patch/MultiDelay.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/MultiDelay/README.md"
-    },
-    {
-        "name": "PluckEcho",
-        "platform": "patch",
-        "filepath": "./dist/patch/PluckEcho.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/PluckEcho/README.md"
-    },
-    {
-        "name": "lfo",
-        "platform": "patch",
-        "filepath": "./dist/patch/lfo.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/lfo/README.md"
-    },
-    {
-        "name": "verb",
-        "platform": "patch",
-        "filepath": "./dist/patch/verb.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/verb/README.md"
-    },
-    {
-        "name": "FilterBank",
-        "platform": "patch",
-        "filepath": "./dist/patch/FilterBank.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/FilterBank/README.md"
-    },
-    {
-        "name": "logic",
-        "platform": "patch",
-        "filepath": "./dist/patch/logic.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/logic/README.md"
-    },
-    {
-        "name": "Compressor",
-        "platform": "patch",
-        "filepath": "./dist/patch/Compressor.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/Compressor/README.md"
-    },
-    {
-        "name": "Midi",
-        "platform": "patch",
-        "filepath": "./dist/patch/Midi.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/Midi/README.md"
-    },
-    {
-        "name": "Torus",
-        "platform": "patch",
-        "filepath": "./dist/patch/Torus.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/Torus/README.md"
-    },
-    {
-        "name": "SampleAndHold",
-        "platform": "patch",
-        "filepath": "./dist/patch/SampleAndHold.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/SampleAndHold/README.md"
-    },
-    {
-        "name": "Svf",
-        "platform": "patch",
-        "filepath": "./dist/patch/Svf.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/Svf/README.md"
-    },
-    {
-        "name": "Sequencer",
-        "platform": "patch",
-        "filepath": "./dist/patch/Sequencer.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/Sequencer/README.md"
-    },
-    {
-        "name": "Nimbus",
-        "platform": "field",
-        "filepath": "./dist/field/Nimbus.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/field/Nimbus/README.md"
-    },
-    {
         "name": "modalvoice",
         "platform": "field",
         "filepath": "./dist/field/modalvoice.bin",
         "description": "no desc available yet",
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/field/modalvoice/README.md"
+    },
+    {
+        "name": "chorus",
+        "platform": "field",
+        "filepath": "./dist/field/chorus.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/field/chorus/README.md"
     },
     {
         "name": "stringvoice",
@@ -175,25 +28,25 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/field/flanger/README.md"
     },
     {
-        "name": "sampler",
-        "platform": "field",
-        "filepath": "./dist/field/sampler.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/field/sampler/README.md"
-    },
-    {
-        "name": "chorus",
-        "platform": "field",
-        "filepath": "./dist/field/chorus.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/field/chorus/README.md"
-    },
-    {
         "name": "Midi",
         "platform": "field",
         "filepath": "./dist/field/Midi.bin",
         "description": "no desc available yet",
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/field/Midi/README.md"
+    },
+    {
+        "name": "Nimbus",
+        "platform": "field",
+        "filepath": "./dist/field/Nimbus.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/field/Nimbus/README.md"
+    },
+    {
+        "name": "sampler",
+        "platform": "field",
+        "filepath": "./dist/field/sampler.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/field/sampler/README.md"
     },
     {
         "name": "KeyboardTest",
@@ -210,158 +63,11 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/field/phaser/README.md"
     },
     {
-        "name": "Decimator",
-        "platform": "versio",
-        "filepath": "./dist/versio/Decimator.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/versio/Decimator/README.md"
-    },
-    {
-        "name": "EnvelopeExample",
-        "platform": "patch_sm",
-        "filepath": "./dist/patch_sm/EnvelopeExample.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/EnvelopeExample/README.md"
-    },
-    {
-        "name": "PassthruExample",
-        "platform": "patch_sm",
-        "filepath": "./dist/patch_sm/PassthruExample.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/PassthruExample/README.md"
-    },
-    {
-        "name": "Toggle_Switch",
-        "platform": "patch_sm_GettingStarted",
-        "filepath": "./dist/patch_sm_GettingStarted/Toggle_Switch.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/GettingStarted/Toggle_Switch/README.md"
-    },
-    {
-        "name": "Gate_Output",
-        "platform": "patch_sm_GettingStarted",
-        "filepath": "./dist/patch_sm_GettingStarted/Gate_Output.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/GettingStarted/Gate_Output/README.md"
-    },
-    {
-        "name": "CV_Output",
-        "platform": "patch_sm_GettingStarted",
-        "filepath": "./dist/patch_sm_GettingStarted/CV_Output.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/GettingStarted/CV_Output/README.md"
-    },
-    {
-        "name": "Audio_Settings",
-        "platform": "patch_sm_GettingStarted",
-        "filepath": "./dist/patch_sm_GettingStarted/Audio_Settings.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/GettingStarted/Audio_Settings/README.md"
-    },
-    {
-        "name": "CV_Input",
-        "platform": "patch_sm_GettingStarted",
-        "filepath": "./dist/patch_sm_GettingStarted/CV_Input.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/GettingStarted/CV_Input/README.md"
-    },
-    {
-        "name": "Pot_Input",
-        "platform": "patch_sm_GettingStarted",
-        "filepath": "./dist/patch_sm_GettingStarted/Pot_Input.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/GettingStarted/Pot_Input/README.md"
-    },
-    {
-        "name": "Momentary_Switch",
-        "platform": "patch_sm_GettingStarted",
-        "filepath": "./dist/patch_sm_GettingStarted/Momentary_Switch.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/GettingStarted/Momentary_Switch/README.md"
-    },
-    {
-        "name": "Gate_Input",
-        "platform": "patch_sm_GettingStarted",
-        "filepath": "./dist/patch_sm_GettingStarted/Gate_Input.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/GettingStarted/Gate_Input/README.md"
-    },
-    {
-        "name": "RandomCvExample",
-        "platform": "patch_sm",
-        "filepath": "./dist/patch_sm/RandomCvExample.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/RandomCvExample/README.md"
-    },
-    {
-        "name": "HardwareTest",
-        "platform": "patch_sm",
-        "filepath": "./dist/patch_sm/HardwareTest.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/HardwareTest/README.md"
-    },
-    {
-        "name": "Looper",
-        "platform": "patch_sm",
-        "filepath": "./dist/patch_sm/Looper.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/Looper/README.md"
-    },
-    {
-        "name": "TripleSaw",
-        "platform": "patch_sm",
-        "filepath": "./dist/patch_sm/TripleSaw.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/TripleSaw/README.md"
-    },
-    {
-        "name": "SimpleOscillator",
-        "platform": "patch_sm",
-        "filepath": "./dist/patch_sm/SimpleOscillator.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/SimpleOscillator/README.md"
-    },
-    {
-        "name": "ReverbExample",
-        "platform": "patch_sm",
-        "filepath": "./dist/patch_sm/ReverbExample.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/ReverbExample/README.md"
-    },
-    {
-        "name": "MultiEffect",
+        "name": "chorus",
         "platform": "petal",
-        "filepath": "./dist/petal/MultiEffect.bin",
+        "filepath": "./dist/petal/chorus.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/MultiEffect/README.md"
-    },
-    {
-        "name": "Verb",
-        "platform": "petal",
-        "filepath": "./dist/petal/Verb.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/Verb/README.md"
-    },
-    {
-        "name": "Looper",
-        "platform": "petal",
-        "filepath": "./dist/petal/Looper.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/Looper/README.md"
-    },
-    {
-        "name": "MultiDelay",
-        "platform": "petal",
-        "filepath": "./dist/petal/MultiDelay.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/MultiDelay/README.md"
-    },
-    {
-        "name": "flanger",
-        "platform": "petal",
-        "filepath": "./dist/petal/flanger.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/flanger/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/chorus/README.md"
     },
     {
         "name": "CombFilter",
@@ -371,11 +77,25 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/CombFilter/README.md"
     },
     {
-        "name": "chorus",
+        "name": "MultiDelay",
         "platform": "petal",
-        "filepath": "./dist/petal/chorus.bin",
+        "filepath": "./dist/petal/MultiDelay.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/chorus/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/MultiDelay/README.md"
+    },
+    {
+        "name": "MultiEffect",
+        "platform": "petal",
+        "filepath": "./dist/petal/MultiEffect.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/MultiEffect/README.md"
+    },
+    {
+        "name": "tremolo",
+        "platform": "petal",
+        "filepath": "./dist/petal/tremolo.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/tremolo/README.md"
     },
     {
         "name": "FilterBank",
@@ -383,6 +103,13 @@
         "filepath": "./dist/petal/FilterBank.bin",
         "description": "no desc available yet",
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/FilterBank/README.md"
+    },
+    {
+        "name": "flanger",
+        "platform": "petal",
+        "filepath": "./dist/petal/flanger.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/flanger/README.md"
     },
     {
         "name": "GeneralFunctionTest",
@@ -399,116 +126,25 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/Distortion/README.md"
     },
     {
+        "name": "Verb",
+        "platform": "petal",
+        "filepath": "./dist/petal/Verb.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/Verb/README.md"
+    },
+    {
+        "name": "Looper",
+        "platform": "petal",
+        "filepath": "./dist/petal/Looper.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/Looper/README.md"
+    },
+    {
         "name": "phaser",
         "platform": "petal",
         "filepath": "./dist/petal/phaser.bin",
         "description": "no desc available yet",
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/phaser/README.md"
-    },
-    {
-        "name": "tremolo",
-        "platform": "petal",
-        "filepath": "./dist/petal/tremolo.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/petal/tremolo/README.md"
-    },
-    {
-        "name": "Encoder",
-        "platform": "pod",
-        "filepath": "./dist/pod/Encoder.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/Encoder/README.md"
-    },
-    {
-        "name": "StepSequencer",
-        "platform": "pod",
-        "filepath": "./dist/pod/StepSequencer.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/StepSequencer/README.md"
-    },
-    {
-        "name": "MultiEffect",
-        "platform": "pod",
-        "filepath": "./dist/pod/MultiEffect.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/MultiEffect/README.md"
-    },
-    {
-        "name": "SynthVoice",
-        "platform": "pod",
-        "filepath": "./dist/pod/SynthVoice.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/SynthVoice/README.md"
-    },
-    {
-        "name": "MusicBox",
-        "platform": "pod",
-        "filepath": "./dist/pod/MusicBox.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/MusicBox/README.md"
-    },
-    {
-        "name": "SimpleLed",
-        "platform": "pod",
-        "filepath": "./dist/pod/SimpleLed.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/SimpleLed/README.md"
-    },
-    {
-        "name": "Looper",
-        "platform": "pod",
-        "filepath": "./dist/pod/Looper.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/Looper/README.md"
-    },
-    {
-        "name": "ChordMachine",
-        "platform": "pod",
-        "filepath": "./dist/pod/ChordMachine.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/ChordMachine/README.md"
-    },
-    {
-        "name": "EuclideanDrums",
-        "platform": "pod",
-        "filepath": "./dist/pod/EuclideanDrums.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/EuclideanDrums/README.md"
-    },
-    {
-        "name": "SimpleButton",
-        "platform": "pod",
-        "filepath": "./dist/pod/SimpleButton.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/SimpleButton/README.md"
-    },
-    {
-        "name": "SimpleOscillator",
-        "platform": "pod",
-        "filepath": "./dist/pod/SimpleOscillator.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/SimpleOscillator/README.md"
-    },
-    {
-        "name": "Midi",
-        "platform": "pod",
-        "filepath": "./dist/pod/Midi.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/Midi/README.md"
-    },
-    {
-        "name": "SDMMC",
-        "platform": "seed",
-        "filepath": "./dist/seed/SDMMC.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/SDMMC/README.md"
-    },
-    {
-        "name": "LCD_HD44780",
-        "platform": "seed",
-        "filepath": "./dist/seed/LCD_HD44780.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/LCD_HD44780/README.md"
     },
     {
         "name": "Button",
@@ -518,18 +154,60 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/Button/README.md"
     },
     {
-        "name": "grainlet",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/grainlet.bin",
+        "name": "OLED",
+        "platform": "seed",
+        "filepath": "./dist/seed/OLED.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/grainlet/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/OLED/README.md"
     },
     {
-        "name": "zoscillator",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/zoscillator.bin",
+        "name": "HWTest",
+        "platform": "seed",
+        "filepath": "./dist/seed/HWTest.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/zoscillator/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/HWTest/README.md"
+    },
+    {
+        "name": "SDMMC",
+        "platform": "seed",
+        "filepath": "./dist/seed/SDMMC.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/SDMMC/README.md"
+    },
+    {
+        "name": "QSPI",
+        "platform": "seed",
+        "filepath": "./dist/seed/QSPI.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/QSPI/README.md"
+    },
+    {
+        "name": "USB_CDC",
+        "platform": "seed",
+        "filepath": "./dist/seed/USB_CDC.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/USB_CDC/README.md"
+    },
+    {
+        "name": "LCD_HD44780",
+        "platform": "seed",
+        "filepath": "./dist/seed/LCD_HD44780.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/LCD_HD44780/README.md"
+    },
+    {
+        "name": "ReceiveTest",
+        "platform": "seed",
+        "filepath": "./dist/seed/ReceiveTest.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/ReceiveTest/README.md"
+    },
+    {
+        "name": "clockednoise",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/clockednoise.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/clockednoise/README.md"
     },
     {
         "name": "metro",
@@ -546,81 +224,11 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/tone/README.md"
     },
     {
-        "name": "crossfade",
+        "name": "analogbassdrum",
         "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/crossfade.bin",
+        "filepath": "./dist/seed_DSP/analogbassdrum.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/crossfade/README.md"
-    },
-    {
-        "name": "resonator",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/resonator.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/resonator/README.md"
-    },
-    {
-        "name": "harmonic_osc",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/harmonic_osc.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/harmonic_osc/README.md"
-    },
-    {
-        "name": "moogladder",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/moogladder.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/moogladder/README.md"
-    },
-    {
-        "name": "delayline",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/delayline.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/delayline/README.md"
-    },
-    {
-        "name": "balance",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/balance.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/balance/README.md"
-    },
-    {
-        "name": "particle",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/particle.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/particle/README.md"
-    },
-    {
-        "name": "reverbsc",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/reverbsc.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/reverbsc/README.md"
-    },
-    {
-        "name": "allpass",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/allpass.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/allpass/README.md"
-    },
-    {
-        "name": "vosim",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/vosim.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/vosim/README.md"
-    },
-    {
-        "name": "blosc",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/blosc.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/blosc/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/analogbassdrum/README.md"
     },
     {
         "name": "modalvoice",
@@ -628,6 +236,48 @@
         "filepath": "./dist/seed_DSP/modalvoice.bin",
         "description": "no desc available yet",
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/modalvoice/README.md"
+    },
+    {
+        "name": "crossfade",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/crossfade.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/crossfade/README.md"
+    },
+    {
+        "name": "Osc",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/Osc.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/Osc/README.md"
+    },
+    {
+        "name": "chorus",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/chorus.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/chorus/README.md"
+    },
+    {
+        "name": "grainlet",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/grainlet.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/grainlet/README.md"
+    },
+    {
+        "name": "varisaw",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/varisaw.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/varisaw/README.md"
+    },
+    {
+        "name": "stringvoice",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/stringvoice.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/stringvoice/README.md"
     },
     {
         "name": "svf",
@@ -644,27 +294,6 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/oscillator/README.md"
     },
     {
-        "name": "Drum",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/Drum.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/Drum/README.md"
-    },
-    {
-        "name": "oscbank",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/oscbank.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/oscbank/README.md"
-    },
-    {
-        "name": "sampleratereducer",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/sampleratereducer.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/sampleratereducer/README.md"
-    },
-    {
         "name": "comb",
         "platform": "seed_DSP",
         "filepath": "./dist/seed_DSP/comb.bin",
@@ -672,11 +301,11 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/comb/README.md"
     },
     {
-        "name": "pitchshifter",
+        "name": "blosc",
         "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/pitchshifter.bin",
+        "filepath": "./dist/seed_DSP/blosc.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/pitchshifter/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/blosc/README.md"
     },
     {
         "name": "fir",
@@ -686,76 +315,6 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/fir/README.md"
     },
     {
-        "name": "fm2",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/fm2.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/fm2/README.md"
-    },
-    {
-        "name": "string",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/string.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/string/README.md"
-    },
-    {
-        "name": "nlfilt",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/nlfilt.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/nlfilt/README.md"
-    },
-    {
-        "name": "analogbassdrum",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/analogbassdrum.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/analogbassdrum/README.md"
-    },
-    {
-        "name": "autowah",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/autowah.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/autowah/README.md"
-    },
-    {
-        "name": "stringvoice",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/stringvoice.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/stringvoice/README.md"
-    },
-    {
-        "name": "varisaw",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/varisaw.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/varisaw/README.md"
-    },
-    {
-        "name": "samplehold",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/samplehold.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/samplehold/README.md"
-    },
-    {
-        "name": "compressor",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/compressor.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/compressor/README.md"
-    },
-    {
-        "name": "jitter",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/jitter.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/jitter/README.md"
-    },
-    {
         "name": "dcblock",
         "platform": "seed_DSP",
         "filepath": "./dist/seed_DSP/dcblock.bin",
@@ -763,18 +322,53 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/dcblock/README.md"
     },
     {
-        "name": "synthbassdrum",
+        "name": "analogsnaredrum",
         "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/synthbassdrum.bin",
+        "filepath": "./dist/seed_DSP/analogsnaredrum.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/synthbassdrum/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/analogsnaredrum/README.md"
     },
     {
-        "name": "decimator",
+        "name": "Drum",
         "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/decimator.bin",
+        "filepath": "./dist/seed_DSP/Drum.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/decimator/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/Drum/README.md"
+    },
+    {
+        "name": "moogladder",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/moogladder.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/moogladder/README.md"
+    },
+    {
+        "name": "zoscillator",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/zoscillator.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/zoscillator/README.md"
+    },
+    {
+        "name": "delayline",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/delayline.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/delayline/README.md"
+    },
+    {
+        "name": "tremolo",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/tremolo.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/tremolo/README.md"
+    },
+    {
+        "name": "harmonic_osc",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/harmonic_osc.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/harmonic_osc/README.md"
     },
     {
         "name": "flanger",
@@ -784,32 +378,18 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/flanger/README.md"
     },
     {
-        "name": "Osc",
+        "name": "balance",
         "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/Osc.bin",
+        "filepath": "./dist/seed_DSP/balance.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/Osc/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/balance/README.md"
     },
     {
-        "name": "line",
+        "name": "reverbsc",
         "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/line.bin",
+        "filepath": "./dist/seed_DSP/reverbsc.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/line/README.md"
-    },
-    {
-        "name": "drip",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/drip.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/drip/README.md"
-    },
-    {
-        "name": "adsr",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/adsr.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/adsr/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/reverbsc/README.md"
     },
     {
         "name": "phasor",
@@ -819,39 +399,25 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/phasor/README.md"
     },
     {
-        "name": "formantosc",
+        "name": "smooth_random",
         "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/formantosc.bin",
+        "filepath": "./dist/seed_DSP/smooth_random.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/formantosc/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/smooth_random/README.md"
     },
     {
-        "name": "variableshapeosc",
+        "name": "allpass",
         "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/variableshapeosc.bin",
+        "filepath": "./dist/seed_DSP/allpass.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/variableshapeosc/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/allpass/README.md"
     },
     {
-        "name": "dust",
+        "name": "whitenoise",
         "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/dust.bin",
+        "filepath": "./dist/seed_DSP/whitenoise.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/dust/README.md"
-    },
-    {
-        "name": "chorus",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/chorus.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/chorus/README.md"
-    },
-    {
-        "name": "port",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/port.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/port/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/whitenoise/README.md"
     },
     {
         "name": "maytrig",
@@ -861,11 +427,25 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/maytrig/README.md"
     },
     {
-        "name": "hihat",
+        "name": "drip",
         "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/hihat.bin",
+        "filepath": "./dist/seed_DSP/drip.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/hihat/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/drip/README.md"
+    },
+    {
+        "name": "bitcrush",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/bitcrush.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/bitcrush/README.md"
+    },
+    {
+        "name": "nlfilt",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/nlfilt.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/nlfilt/README.md"
     },
     {
         "name": "faustnoise",
@@ -882,88 +462,18 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/adenv/README.md"
     },
     {
-        "name": "synthsnaredrum",
+        "name": "string",
         "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/synthsnaredrum.bin",
+        "filepath": "./dist/seed_DSP/string.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/synthsnaredrum/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/string/README.md"
     },
     {
-        "name": "analogsnaredrum",
+        "name": "adsr",
         "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/analogsnaredrum.bin",
+        "filepath": "./dist/seed_DSP/adsr.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/analogsnaredrum/README.md"
-    },
-    {
-        "name": "bitcrush",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/bitcrush.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/bitcrush/README.md"
-    },
-    {
-        "name": "whitenoise",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/whitenoise.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/whitenoise/README.md"
-    },
-    {
-        "name": "phaser",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/phaser.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/phaser/README.md"
-    },
-    {
-        "name": "clockednoise",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/clockednoise.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/clockednoise/README.md"
-    },
-    {
-        "name": "pluck",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/pluck.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/pluck/README.md"
-    },
-    {
-        "name": "fractal_noise",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/fractal_noise.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/fractal_noise/README.md"
-    },
-    {
-        "name": "biquad",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/biquad.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/biquad/README.md"
-    },
-    {
-        "name": "atone",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/atone.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/atone/README.md"
-    },
-    {
-        "name": "tremolo",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/tremolo.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/tremolo/README.md"
-    },
-    {
-        "name": "smooth_random",
-        "platform": "seed_DSP",
-        "filepath": "./dist/seed_DSP/smooth_random.bin",
-        "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/smooth_random/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/adsr/README.md"
     },
     {
         "name": "overdrive",
@@ -973,53 +483,179 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/overdrive/README.md"
     },
     {
-        "name": "QSPI",
-        "platform": "seed",
-        "filepath": "./dist/seed/QSPI.bin",
+        "name": "pluck",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/pluck.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/QSPI/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/pluck/README.md"
     },
     {
-        "name": "ReceiveTest",
-        "platform": "seed",
-        "filepath": "./dist/seed/ReceiveTest.bin",
+        "name": "biquad",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/biquad.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/ReceiveTest/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/biquad/README.md"
     },
     {
-        "name": "Blink",
-        "platform": "seed",
-        "filepath": "./dist/seed/Blink.bin",
+        "name": "fm2",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/fm2.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/Blink/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/fm2/README.md"
     },
     {
-        "name": "Logger",
-        "platform": "seed",
-        "filepath": "./dist/seed/Logger.bin",
+        "name": "variableshapeosc",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/variableshapeosc.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/Logger/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/variableshapeosc/README.md"
     },
     {
-        "name": "USB_CDC",
-        "platform": "seed",
-        "filepath": "./dist/seed/USB_CDC.bin",
+        "name": "jitter",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/jitter.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/USB_CDC/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/jitter/README.md"
     },
     {
-        "name": "USB_MIDI",
-        "platform": "seed",
-        "filepath": "./dist/seed/USB_MIDI.bin",
+        "name": "line",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/line.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/USB_MIDI/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/line/README.md"
     },
     {
-        "name": "bypass",
-        "platform": "seed",
-        "filepath": "./dist/seed/bypass.bin",
+        "name": "resonator",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/resonator.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/bypass/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/resonator/README.md"
+    },
+    {
+        "name": "pitchshifter",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/pitchshifter.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/pitchshifter/README.md"
+    },
+    {
+        "name": "hihat",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/hihat.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/hihat/README.md"
+    },
+    {
+        "name": "vosim",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/vosim.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/vosim/README.md"
+    },
+    {
+        "name": "dust",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/dust.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/dust/README.md"
+    },
+    {
+        "name": "fractal_noise",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/fractal_noise.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/fractal_noise/README.md"
+    },
+    {
+        "name": "oscbank",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/oscbank.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/oscbank/README.md"
+    },
+    {
+        "name": "particle",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/particle.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/particle/README.md"
+    },
+    {
+        "name": "synthbassdrum",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/synthbassdrum.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/synthbassdrum/README.md"
+    },
+    {
+        "name": "atone",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/atone.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/atone/README.md"
+    },
+    {
+        "name": "compressor",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/compressor.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/compressor/README.md"
+    },
+    {
+        "name": "sampleratereducer",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/sampleratereducer.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/sampleratereducer/README.md"
+    },
+    {
+        "name": "autowah",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/autowah.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/autowah/README.md"
+    },
+    {
+        "name": "decimator",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/decimator.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/decimator/README.md"
+    },
+    {
+        "name": "port",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/port.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/port/README.md"
+    },
+    {
+        "name": "synthsnaredrum",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/synthsnaredrum.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/synthsnaredrum/README.md"
+    },
+    {
+        "name": "formantosc",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/formantosc.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/formantosc/README.md"
+    },
+    {
+        "name": "samplehold",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/samplehold.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/samplehold/README.md"
+    },
+    {
+        "name": "phaser",
+        "platform": "seed_DSP",
+        "filepath": "./dist/seed_DSP/phaser.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/DSP/phaser/README.md"
     },
     {
         "name": "Ram",
@@ -1036,18 +672,25 @@
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/WavPlayer/README.md"
     },
     {
-        "name": "HWTest",
+        "name": "Logger",
         "platform": "seed",
-        "filepath": "./dist/seed/HWTest.bin",
+        "filepath": "./dist/seed/Logger.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/HWTest/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/Logger/README.md"
     },
     {
-        "name": "OLED",
+        "name": "bypass",
         "platform": "seed",
-        "filepath": "./dist/seed/OLED.bin",
+        "filepath": "./dist/seed/bypass.bin",
         "description": "no desc available yet",
-        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/OLED/README.md"
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/bypass/README.md"
+    },
+    {
+        "name": "Blink",
+        "platform": "seed",
+        "filepath": "./dist/seed/Blink.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/Blink/README.md"
     },
     {
         "name": "Knob",
@@ -1055,5 +698,362 @@
         "filepath": "./dist/seed/Knob.bin",
         "description": "no desc available yet",
         "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/Knob/README.md"
+    },
+    {
+        "name": "USB_MIDI",
+        "platform": "seed",
+        "filepath": "./dist/seed/USB_MIDI.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/seed/USB_MIDI/README.md"
+    },
+    {
+        "name": "PolyOsc",
+        "platform": "patch",
+        "filepath": "./dist/patch/PolyOsc.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/PolyOsc/README.md"
+    },
+    {
+        "name": "lfo",
+        "platform": "patch",
+        "filepath": "./dist/patch/lfo.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/lfo/README.md"
+    },
+    {
+        "name": "logic",
+        "platform": "patch",
+        "filepath": "./dist/patch/logic.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/logic/README.md"
+    },
+    {
+        "name": "vco",
+        "platform": "patch",
+        "filepath": "./dist/patch/vco.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/vco/README.md"
+    },
+    {
+        "name": "EnvelopeOscillator",
+        "platform": "patch",
+        "filepath": "./dist/patch/EnvelopeOscillator.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/EnvelopeOscillator/README.md"
+    },
+    {
+        "name": "Compressor",
+        "platform": "patch",
+        "filepath": "./dist/patch/Compressor.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/Compressor/README.md"
+    },
+    {
+        "name": "verb",
+        "platform": "patch",
+        "filepath": "./dist/patch/verb.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/verb/README.md"
+    },
+    {
+        "name": "MultiDelay",
+        "platform": "patch",
+        "filepath": "./dist/patch/MultiDelay.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/MultiDelay/README.md"
+    },
+    {
+        "name": "QuadraphonicMixer",
+        "platform": "patch",
+        "filepath": "./dist/patch/QuadraphonicMixer.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/QuadraphonicMixer/README.md"
+    },
+    {
+        "name": "QuadMixer",
+        "platform": "patch",
+        "filepath": "./dist/patch/QuadMixer.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/QuadMixer/README.md"
+    },
+    {
+        "name": "FilterBank",
+        "platform": "patch",
+        "filepath": "./dist/patch/FilterBank.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/FilterBank/README.md"
+    },
+    {
+        "name": "Midi",
+        "platform": "patch",
+        "filepath": "./dist/patch/Midi.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/Midi/README.md"
+    },
+    {
+        "name": "QuadEnvelope",
+        "platform": "patch",
+        "filepath": "./dist/patch/QuadEnvelope.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/QuadEnvelope/README.md"
+    },
+    {
+        "name": "SequentialSwitch",
+        "platform": "patch",
+        "filepath": "./dist/patch/SequentialSwitch.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/SequentialSwitch/README.md"
+    },
+    {
+        "name": "Svf",
+        "platform": "patch",
+        "filepath": "./dist/patch/Svf.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/Svf/README.md"
+    },
+    {
+        "name": "Sequencer",
+        "platform": "patch",
+        "filepath": "./dist/patch/Sequencer.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/Sequencer/README.md"
+    },
+    {
+        "name": "SampleAndHold",
+        "platform": "patch",
+        "filepath": "./dist/patch/SampleAndHold.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/SampleAndHold/README.md"
+    },
+    {
+        "name": "PluckEcho",
+        "platform": "patch",
+        "filepath": "./dist/patch/PluckEcho.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/PluckEcho/README.md"
+    },
+    {
+        "name": "Nimbus",
+        "platform": "patch",
+        "filepath": "./dist/patch/Nimbus.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/Nimbus/README.md"
+    },
+    {
+        "name": "Torus",
+        "platform": "patch",
+        "filepath": "./dist/patch/Torus.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/Torus/README.md"
+    },
+    {
+        "name": "Noise",
+        "platform": "patch",
+        "filepath": "./dist/patch/Noise.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch/Noise/README.md"
+    },
+    {
+        "name": "MultiEffect",
+        "platform": "pod",
+        "filepath": "./dist/pod/MultiEffect.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/MultiEffect/README.md"
+    },
+    {
+        "name": "Encoder",
+        "platform": "pod",
+        "filepath": "./dist/pod/Encoder.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/Encoder/README.md"
+    },
+    {
+        "name": "EuclideanDrums",
+        "platform": "pod",
+        "filepath": "./dist/pod/EuclideanDrums.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/EuclideanDrums/README.md"
+    },
+    {
+        "name": "SimpleOscillator",
+        "platform": "pod",
+        "filepath": "./dist/pod/SimpleOscillator.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/SimpleOscillator/README.md"
+    },
+    {
+        "name": "Midi",
+        "platform": "pod",
+        "filepath": "./dist/pod/Midi.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/Midi/README.md"
+    },
+    {
+        "name": "ChordMachine",
+        "platform": "pod",
+        "filepath": "./dist/pod/ChordMachine.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/ChordMachine/README.md"
+    },
+    {
+        "name": "SimpleButton",
+        "platform": "pod",
+        "filepath": "./dist/pod/SimpleButton.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/SimpleButton/README.md"
+    },
+    {
+        "name": "StepSequencer",
+        "platform": "pod",
+        "filepath": "./dist/pod/StepSequencer.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/StepSequencer/README.md"
+    },
+    {
+        "name": "SynthVoice",
+        "platform": "pod",
+        "filepath": "./dist/pod/SynthVoice.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/SynthVoice/README.md"
+    },
+    {
+        "name": "SimpleLed",
+        "platform": "pod",
+        "filepath": "./dist/pod/SimpleLed.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/SimpleLed/README.md"
+    },
+    {
+        "name": "Looper",
+        "platform": "pod",
+        "filepath": "./dist/pod/Looper.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/Looper/README.md"
+    },
+    {
+        "name": "MusicBox",
+        "platform": "pod",
+        "filepath": "./dist/pod/MusicBox.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/pod/MusicBox/README.md"
+    },
+    {
+        "name": "HardwareTest",
+        "platform": "patch_sm",
+        "filepath": "./dist/patch_sm/HardwareTest.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/HardwareTest/README.md"
+    },
+    {
+        "name": "SimpleOscillator",
+        "platform": "patch_sm",
+        "filepath": "./dist/patch_sm/SimpleOscillator.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/SimpleOscillator/README.md"
+    },
+    {
+        "name": "ReverbExample",
+        "platform": "patch_sm",
+        "filepath": "./dist/patch_sm/ReverbExample.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/ReverbExample/README.md"
+    },
+    {
+        "name": "Momentary_Switch",
+        "platform": "patch_sm_GettingStarted",
+        "filepath": "./dist/patch_sm_GettingStarted/Momentary_Switch.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/GettingStarted/Momentary_Switch/README.md"
+    },
+    {
+        "name": "CV_Output",
+        "platform": "patch_sm_GettingStarted",
+        "filepath": "./dist/patch_sm_GettingStarted/CV_Output.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/GettingStarted/CV_Output/README.md"
+    },
+    {
+        "name": "CV_Input",
+        "platform": "patch_sm_GettingStarted",
+        "filepath": "./dist/patch_sm_GettingStarted/CV_Input.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/GettingStarted/CV_Input/README.md"
+    },
+    {
+        "name": "Audio_Settings",
+        "platform": "patch_sm_GettingStarted",
+        "filepath": "./dist/patch_sm_GettingStarted/Audio_Settings.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/GettingStarted/Audio_Settings/README.md"
+    },
+    {
+        "name": "Gate_Output",
+        "platform": "patch_sm_GettingStarted",
+        "filepath": "./dist/patch_sm_GettingStarted/Gate_Output.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/GettingStarted/Gate_Output/README.md"
+    },
+    {
+        "name": "Gate_Input",
+        "platform": "patch_sm_GettingStarted",
+        "filepath": "./dist/patch_sm_GettingStarted/Gate_Input.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/GettingStarted/Gate_Input/README.md"
+    },
+    {
+        "name": "Toggle_Switch",
+        "platform": "patch_sm_GettingStarted",
+        "filepath": "./dist/patch_sm_GettingStarted/Toggle_Switch.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/GettingStarted/Toggle_Switch/README.md"
+    },
+    {
+        "name": "Pot_Input",
+        "platform": "patch_sm_GettingStarted",
+        "filepath": "./dist/patch_sm_GettingStarted/Pot_Input.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/GettingStarted/Pot_Input/README.md"
+    },
+    {
+        "name": "PassthruExample",
+        "platform": "patch_sm",
+        "filepath": "./dist/patch_sm/PassthruExample.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/PassthruExample/README.md"
+    },
+    {
+        "name": "TripleSaw",
+        "platform": "patch_sm",
+        "filepath": "./dist/patch_sm/TripleSaw.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/TripleSaw/README.md"
+    },
+    {
+        "name": "EnvelopeExample",
+        "platform": "patch_sm",
+        "filepath": "./dist/patch_sm/EnvelopeExample.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/EnvelopeExample/README.md"
+    },
+    {
+        "name": "Looper",
+        "platform": "patch_sm",
+        "filepath": "./dist/patch_sm/Looper.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/Looper/README.md"
+    },
+    {
+        "name": "RandomCvExample",
+        "platform": "patch_sm",
+        "filepath": "./dist/patch_sm/RandomCvExample.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/patch_sm/RandomCvExample/README.md"
+    },
+    {
+        "name": "Decimator",
+        "platform": "versio",
+        "filepath": "./dist/versio/Decimator.bin",
+        "description": "no desc available yet",
+        "url": "https://raw.githubusercontent.com/electro-smith/DaisyExamples/master/versio/Decimator/README.md"
     }
 ]

--- a/field/KeyboardTest/Makefile
+++ b/field/KeyboardTest/Makefile
@@ -5,7 +5,7 @@ TARGET = ex_field_keyboard_test
 CPP_SOURCES = KeyboardTest.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/field/Midi/Makefile
+++ b/field/Midi/Makefile
@@ -5,7 +5,7 @@ TARGET = FieldMidi
 CPP_SOURCES = Midi.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/field/Nimbus/Makefile
+++ b/field/Nimbus/Makefile
@@ -12,7 +12,7 @@ dsp/pvoc/stft.cpp \
 resources.cpp \
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 #C_SOURCES += \

--- a/field/chorus/Makefile
+++ b/field/chorus/Makefile
@@ -5,7 +5,7 @@ TARGET = chorus
 CPP_SOURCES = chorus.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/field/flanger/Makefile
+++ b/field/flanger/Makefile
@@ -5,7 +5,7 @@ TARGET = flanger
 CPP_SOURCES = flanger.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/field/modalvoice/Makefile
+++ b/field/modalvoice/Makefile
@@ -5,7 +5,7 @@ TARGET = modalvoice
 CPP_SOURCES = modalvoice.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/field/phaser/Makefile
+++ b/field/phaser/Makefile
@@ -5,7 +5,7 @@ TARGET = phaser
 CPP_SOURCES = phaser.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/field/sampler/Makefile
+++ b/field/sampler/Makefile
@@ -5,7 +5,7 @@ TARGET = sampler
 CPP_SOURCES = sampler.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/field/stringvoice/Makefile
+++ b/field/stringvoice/Makefile
@@ -5,7 +5,7 @@ TARGET = stringvoice
 CPP_SOURCES = stringvoice.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/patch/Compressor/Makefile
+++ b/patch/Compressor/Makefile
@@ -5,7 +5,7 @@ TARGET = Compressor
 CPP_SOURCES = Compressor.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/patch/EnvelopeOscillator/Makefile
+++ b/patch/EnvelopeOscillator/Makefile
@@ -5,7 +5,7 @@ TARGET = EnvelopeOscillator
 CPP_SOURCES = EnvelopeOscillator.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/patch/FilterBank/Makefile
+++ b/patch/FilterBank/Makefile
@@ -5,7 +5,7 @@ TARGET = FilterBank
 CPP_SOURCES = FilterBank.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/patch/Midi/Makefile
+++ b/patch/Midi/Makefile
@@ -5,7 +5,7 @@ TARGET = Midi
 CPP_SOURCES = Midi.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/patch/MultiDelay/Makefile
+++ b/patch/MultiDelay/Makefile
@@ -5,7 +5,7 @@ TARGET = MultiDelay
 CPP_SOURCES = MultiDelay.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/patch/Nimbus/Makefile
+++ b/patch/Nimbus/Makefile
@@ -12,7 +12,7 @@ dsp/pvoc/stft.cpp \
 resources.cpp \
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 #C_SOURCES += \

--- a/patch/Noise/Makefile
+++ b/patch/Noise/Makefile
@@ -5,7 +5,7 @@ TARGET = Noise
 CPP_SOURCES = Noise.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/patch/PluckEcho/Makefile
+++ b/patch/PluckEcho/Makefile
@@ -5,7 +5,7 @@ TARGET = PluckEcho
 CPP_SOURCES = PluckEcho.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/patch/PolyOsc/Makefile
+++ b/patch/PolyOsc/Makefile
@@ -5,7 +5,7 @@ TARGET = PolyOsc
 CPP_SOURCES = PolyOsc.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/patch/QuadEnvelope/Makefile
+++ b/patch/QuadEnvelope/Makefile
@@ -5,7 +5,7 @@ TARGET = QuadEnvelope
 CPP_SOURCES = QuadEnvelope.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/patch/QuadMixer/Makefile
+++ b/patch/QuadMixer/Makefile
@@ -5,7 +5,7 @@ TARGET = QuadMixer
 CPP_SOURCES = QuadMixer.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/patch/QuadraphonicMixer/Makefile
+++ b/patch/QuadraphonicMixer/Makefile
@@ -5,7 +5,7 @@ TARGET = QuadraphonicMixer
 CPP_SOURCES = QuadraphonicMixer.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/patch/SampleAndHold/Makefile
+++ b/patch/SampleAndHold/Makefile
@@ -5,7 +5,7 @@ TARGET = SampleAndHold
 CPP_SOURCES = SampleAndHold.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/patch/Sequencer/Makefile
+++ b/patch/Sequencer/Makefile
@@ -5,7 +5,7 @@ TARGET = Sequencer
 CPP_SOURCES = Sequencer.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/patch/SequentialSwitch/Makefile
+++ b/patch/SequentialSwitch/Makefile
@@ -5,7 +5,7 @@ TARGET = SequentialSwitch
 CPP_SOURCES = SequentialSwitch.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/patch/Svf/Makefile
+++ b/patch/Svf/Makefile
@@ -5,7 +5,7 @@ TARGET = Svf
 CPP_SOURCES = Svf.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/patch/Torus/Makefile
+++ b/patch/Torus/Makefile
@@ -2,7 +2,7 @@
 TARGET = torus
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 STMLIB_DIR = ../../stmlib
 
 # Sources

--- a/patch/lfo/Makefile
+++ b/patch/lfo/Makefile
@@ -5,7 +5,7 @@ TARGET = lfo
 CPP_SOURCES = lfo.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/patch/logic/Makefile
+++ b/patch/logic/Makefile
@@ -5,7 +5,7 @@ TARGET = logic
 CPP_SOURCES = logic.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/patch/vco/Makefile
+++ b/patch/vco/Makefile
@@ -5,7 +5,7 @@ TARGET = ex_vco
 CPP_SOURCES = ex_vco.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/patch/verb/Makefile
+++ b/patch/verb/Makefile
@@ -5,7 +5,7 @@ TARGET = ex_verb
 CPP_SOURCES = ex_verb.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/patch_sm/EnvelopeExample/Makefile
+++ b/patch_sm/EnvelopeExample/Makefile
@@ -5,7 +5,7 @@ TARGET = EnvelopeExample
 CPP_SOURCES = EnvelopeExample.cpp \
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy/
+LIBDAISY_DIR = ../../libDaisy/
 DAISYSP_DIR = ../../DaisySP/
 
 # Core location, and generic Makefile.

--- a/patch_sm/GettingStarted/Audio_Settings/Makefile
+++ b/patch_sm/GettingStarted/Audio_Settings/Makefile
@@ -5,7 +5,7 @@ TARGET = Audio_Settings
 CPP_SOURCES = Audio_Settings.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy/
+LIBDAISY_DIR = ../../../libDaisy/
 DAISYSP_DIR = ../../../DaisySP/
 
 # Core location, and generic Makefile.

--- a/patch_sm/GettingStarted/CV_Input/Makefile
+++ b/patch_sm/GettingStarted/CV_Input/Makefile
@@ -5,7 +5,7 @@ TARGET = CV_Input
 CPP_SOURCES = CV_Input.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy/
+LIBDAISY_DIR = ../../../libDaisy/
 DAISYSP_DIR = ../../../DaisySP/
 
 # Core location, and generic Makefile.

--- a/patch_sm/GettingStarted/CV_Output/Makefile
+++ b/patch_sm/GettingStarted/CV_Output/Makefile
@@ -5,7 +5,7 @@ TARGET = CV_Output
 CPP_SOURCES = CV_Output.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy/
+LIBDAISY_DIR = ../../../libDaisy/
 DAISYSP_DIR = ../../../DaisySP/
 
 # Core location, and generic Makefile.

--- a/patch_sm/GettingStarted/Gate_Input/Makefile
+++ b/patch_sm/GettingStarted/Gate_Input/Makefile
@@ -5,7 +5,7 @@ TARGET = Gate_Input
 CPP_SOURCES = Gate_Input.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy/
+LIBDAISY_DIR = ../../../libDaisy/
 DAISYSP_DIR = ../../../DaisySP/
 
 # Core location, and generic Makefile.

--- a/patch_sm/GettingStarted/Gate_Output/Makefile
+++ b/patch_sm/GettingStarted/Gate_Output/Makefile
@@ -5,7 +5,7 @@ TARGET = Gate_Output
 CPP_SOURCES = Gate_Output.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy/
+LIBDAISY_DIR = ../../../libDaisy/
 DAISYSP_DIR = ../../../DaisySP/
 
 # Core location, and generic Makefile.

--- a/patch_sm/GettingStarted/Momentary_Switch/Makefile
+++ b/patch_sm/GettingStarted/Momentary_Switch/Makefile
@@ -5,7 +5,7 @@ TARGET = Momentary_Switch
 CPP_SOURCES = Momentary_Switch.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy/
+LIBDAISY_DIR = ../../../libDaisy/
 DAISYSP_DIR = ../../../DaisySP/
 
 # Core location, and generic Makefile.

--- a/patch_sm/GettingStarted/Pot_Input/Makefile
+++ b/patch_sm/GettingStarted/Pot_Input/Makefile
@@ -5,7 +5,7 @@ TARGET = Pot_Input
 CPP_SOURCES = Pot_Input.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy/
+LIBDAISY_DIR = ../../../libDaisy/
 DAISYSP_DIR = ../../../DaisySP/
 
 # Core location, and generic Makefile.

--- a/patch_sm/GettingStarted/Toggle_Switch/Makefile
+++ b/patch_sm/GettingStarted/Toggle_Switch/Makefile
@@ -5,7 +5,7 @@ TARGET = Toggle_Switch
 CPP_SOURCES = Toggle_Switch.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy/
+LIBDAISY_DIR = ../../../libDaisy/
 DAISYSP_DIR = ../../../DaisySP/
 
 # Core location, and generic Makefile.

--- a/patch_sm/HardwareTest/Makefile
+++ b/patch_sm/HardwareTest/Makefile
@@ -7,7 +7,7 @@ USE_FATFS = 1
 CPP_SOURCES = HardwareTest.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy/
+LIBDAISY_DIR = ../../libDaisy/
 DAISYSP_DIR = ../../DaisySP/
 
 # Core location, and generic Makefile.

--- a/patch_sm/Looper/Makefile
+++ b/patch_sm/Looper/Makefile
@@ -5,7 +5,7 @@ TARGET = Looper
 CPP_SOURCES = Looper.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy/
+LIBDAISY_DIR = ../../libDaisy/
 DAISYSP_DIR = ../../DaisySP/
 
 # Core location, and generic Makefile.

--- a/patch_sm/PassthruExample/Makefile
+++ b/patch_sm/PassthruExample/Makefile
@@ -5,7 +5,7 @@ TARGET = PassthruExample
 CPP_SOURCES = PassthruExample.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy/
+LIBDAISY_DIR = ../../libDaisy/
 DAISYSP_DIR = ../../DaisySP/
 
 # Core location, and generic Makefile.

--- a/patch_sm/RandomCvExample/Makefile
+++ b/patch_sm/RandomCvExample/Makefile
@@ -5,7 +5,7 @@ TARGET = RandomCvExample
 CPP_SOURCES = RandomCvExample.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy/
+LIBDAISY_DIR = ../../libDaisy/
 DAISYSP_DIR = ../../DaisySP/
 
 # Core location, and generic Makefile.

--- a/patch_sm/ReverbExample/Makefile
+++ b/patch_sm/ReverbExample/Makefile
@@ -5,7 +5,7 @@ TARGET = ReverbExample
 CPP_SOURCES = ReverbExample.cpp \
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy/
+LIBDAISY_DIR = ../../libDaisy/
 DAISYSP_DIR = ../../DaisySP/
 
 

--- a/patch_sm/SimpleOscillator/Makefile
+++ b/patch_sm/SimpleOscillator/Makefile
@@ -5,7 +5,7 @@ TARGET = SimpleOscillator
 CPP_SOURCES = SimpleOscillator.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy/
+LIBDAISY_DIR = ../../libDaisy/
 DAISYSP_DIR = ../../DaisySP/
 
 # Core location, and generic Makefile.

--- a/patch_sm/TripleSaw/Makefile
+++ b/patch_sm/TripleSaw/Makefile
@@ -5,7 +5,7 @@ TARGET = TripleSaw
 CPP_SOURCES = TripleSaw.cpp \
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy/
+LIBDAISY_DIR = ../../libDaisy/
 DAISYSP_DIR = ../../DaisySP/
 
 # Core location, and generic Makefile.

--- a/petal/CombFilter/Makefile
+++ b/petal/CombFilter/Makefile
@@ -5,7 +5,7 @@ TARGET = CombFilter
 CPP_SOURCES = CombFilter.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/petal/Distortion/Makefile
+++ b/petal/Distortion/Makefile
@@ -5,7 +5,7 @@ TARGET = Distortion
 CPP_SOURCES = Distortion.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic makefile.

--- a/petal/FilterBank/Makefile
+++ b/petal/FilterBank/Makefile
@@ -5,7 +5,7 @@ TARGET = FilterBank
 CPP_SOURCES = FilterBank.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/petal/GeneralFunctionTest/Makefile
+++ b/petal/GeneralFunctionTest/Makefile
@@ -5,7 +5,7 @@ TARGET = GeneralFunctionTest
 CPP_SOURCES = GeneralFunctionTest.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Includes FatFS source files within project.

--- a/petal/Looper/Makefile
+++ b/petal/Looper/Makefile
@@ -5,7 +5,7 @@ TARGET = ex_Looper
 CPP_SOURCES = Looper.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic makefile.

--- a/petal/MultiDelay/Makefile
+++ b/petal/MultiDelay/Makefile
@@ -5,7 +5,7 @@ TARGET = MultiDelay
 CPP_SOURCES = MultiDelay.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/petal/MultiEffect/Makefile
+++ b/petal/MultiEffect/Makefile
@@ -5,7 +5,7 @@ TARGET = MultiEffect
 CPP_SOURCES = MultiEffect.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/petal/Verb/Makefile
+++ b/petal/Verb/Makefile
@@ -5,7 +5,7 @@ TARGET = Verb
 CPP_SOURCES = Verb.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/petal/chorus/Makefile
+++ b/petal/chorus/Makefile
@@ -8,7 +8,7 @@ OPT = -Og
 CPP_SOURCES = chorus.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/petal/flanger/Makefile
+++ b/petal/flanger/Makefile
@@ -5,7 +5,7 @@ TARGET = flanger
 CPP_SOURCES = flanger.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/petal/phaser/Makefile
+++ b/petal/phaser/Makefile
@@ -5,7 +5,7 @@ TARGET = phaser
 CPP_SOURCES = phaser.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/petal/tremolo/Makefile
+++ b/petal/tremolo/Makefile
@@ -5,7 +5,7 @@ TARGET = tremolo
 CPP_SOURCES = tremolo.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/pod/ChordMachine/Makefile
+++ b/pod/ChordMachine/Makefile
@@ -5,7 +5,7 @@ TARGET = ChordMachine
 CPP_SOURCES = ChordMachine.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/pod/Encoder/Makefile
+++ b/pod/Encoder/Makefile
@@ -5,7 +5,7 @@ TARGET = ex_pod_Encoder
 CPP_SOURCES = main.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/pod/EuclideanDrums/Makefile
+++ b/pod/EuclideanDrums/Makefile
@@ -5,7 +5,7 @@ TARGET = EuclideanDrums
 CPP_SOURCES = EuclideanDrums.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/pod/Looper/Makefile
+++ b/pod/Looper/Makefile
@@ -5,7 +5,7 @@ TARGET = ex_Looper
 CPP_SOURCES = Looper.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic makefile.

--- a/pod/Midi/Makefile
+++ b/pod/Midi/Makefile
@@ -5,7 +5,7 @@ TARGET = Midi
 CPP_SOURCES = Midi.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/pod/MultiEffect/Makefile
+++ b/pod/MultiEffect/Makefile
@@ -5,7 +5,7 @@ TARGET = MultiEffect
 CPP_SOURCES = MultiEffect.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/pod/MusicBox/Makefile
+++ b/pod/MusicBox/Makefile
@@ -5,7 +5,7 @@ TARGET = MusicBox
 CPP_SOURCES = MusicBox.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/pod/SimpleButton/Makefile
+++ b/pod/SimpleButton/Makefile
@@ -4,7 +4,7 @@ TARGET = SimpleButton
 CPP_SOURCES = SimpleButton.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/pod/SimpleLed/Makefile
+++ b/pod/SimpleLed/Makefile
@@ -5,7 +5,7 @@ TARGET = SimpleLed
 CPP_SOURCES = SimpleLed.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/pod/SimpleOscillator/Makefile
+++ b/pod/SimpleOscillator/Makefile
@@ -5,7 +5,7 @@ TARGET = SimpleOscillator
 CPP_SOURCES = SimpleOscillator.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/pod/StepSequencer/Makefile
+++ b/pod/StepSequencer/Makefile
@@ -5,7 +5,7 @@ TARGET = StepSequencer
 CPP_SOURCES = StepSequencer.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/pod/SynthVoice/Makefile
+++ b/pod/SynthVoice/Makefile
@@ -5,7 +5,7 @@ TARGET = ex_SynthVoice
 CPP_SOURCES = SynthVoice.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic makefile.

--- a/seed/Blink/Makefile
+++ b/seed/Blink/Makefile
@@ -5,7 +5,7 @@ TARGET = Blink
 CPP_SOURCES = Blink.cpp 
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic makefile.

--- a/seed/Button/Makefile
+++ b/seed/Button/Makefile
@@ -5,7 +5,7 @@ TARGET = Button
 CPP_SOURCES = Button.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic makefile.

--- a/seed/DSP/Drum/Makefile
+++ b/seed/DSP/Drum/Makefile
@@ -5,7 +5,7 @@ TARGET = Drum
 CPP_SOURCES = Drum.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic makefile.

--- a/seed/DSP/Osc/Makefile
+++ b/seed/DSP/Osc/Makefile
@@ -5,7 +5,7 @@ TARGET = Osc
 CPP_SOURCES = Osc.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic makefile.

--- a/seed/DSP/adenv/Makefile
+++ b/seed/DSP/adenv/Makefile
@@ -6,7 +6,7 @@ CPP_SOURCES = adenv.cpp
 
 # Library Locations
 DAISYSP_DIR ?= ../../../DaisySP
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 
 # Core location, and generic Makefile.
 # Overwrite LIBDAISY Environment variable to the location of the lib on your machine.

--- a/seed/DSP/adsr/Makefile
+++ b/seed/DSP/adsr/Makefile
@@ -5,7 +5,7 @@ TARGET = adsr
 CPP_SOURCES = adsr.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/allpass/Makefile
+++ b/seed/DSP/allpass/Makefile
@@ -5,7 +5,7 @@ TARGET = allpass
 CPP_SOURCES = allpass.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/analogbassdrum/Makefile
+++ b/seed/DSP/analogbassdrum/Makefile
@@ -5,7 +5,7 @@ TARGET = analogbassdrum
 CPP_SOURCES = analogbassdrum.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/analogsnaredrum/Makefile
+++ b/seed/DSP/analogsnaredrum/Makefile
@@ -5,7 +5,7 @@ TARGET = analogsnaredrum
 CPP_SOURCES = analogsnaredrum.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/atone/Makefile
+++ b/seed/DSP/atone/Makefile
@@ -5,7 +5,7 @@ TARGET = atone
 CPP_SOURCES = atone.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/autowah/Makefile
+++ b/seed/DSP/autowah/Makefile
@@ -5,7 +5,7 @@ TARGET = autowah
 CPP_SOURCES = autowah.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/balance/Makefile
+++ b/seed/DSP/balance/Makefile
@@ -5,7 +5,7 @@ TARGET = balance
 CPP_SOURCES = balance.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/biquad/Makefile
+++ b/seed/DSP/biquad/Makefile
@@ -5,7 +5,7 @@ TARGET = biquad
 CPP_SOURCES = biquad.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/bitcrush/Makefile
+++ b/seed/DSP/bitcrush/Makefile
@@ -5,7 +5,7 @@ TARGET = bitcrush
 CPP_SOURCES = bitcrush.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/blosc/Makefile
+++ b/seed/DSP/blosc/Makefile
@@ -5,7 +5,7 @@ TARGET = blosc
 CPP_SOURCES = blosc.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/chorus/Makefile
+++ b/seed/DSP/chorus/Makefile
@@ -5,7 +5,7 @@ TARGET = chorus
 CPP_SOURCES = chorus.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/clockednoise/Makefile
+++ b/seed/DSP/clockednoise/Makefile
@@ -5,7 +5,7 @@ TARGET = clockednoise
 CPP_SOURCES = clockednoise.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/comb/Makefile
+++ b/seed/DSP/comb/Makefile
@@ -5,7 +5,7 @@ TARGET = comb
 CPP_SOURCES = comb.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/compressor/Makefile
+++ b/seed/DSP/compressor/Makefile
@@ -5,7 +5,7 @@ TARGET = compressor
 CPP_SOURCES = compressor.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/crossfade/Makefile
+++ b/seed/DSP/crossfade/Makefile
@@ -5,7 +5,7 @@ TARGET = crossfade
 CPP_SOURCES = crossfade.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/dcblock/Makefile
+++ b/seed/DSP/dcblock/Makefile
@@ -5,7 +5,7 @@ TARGET = dcblock
 CPP_SOURCES = dcblock.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/decimator/Makefile
+++ b/seed/DSP/decimator/Makefile
@@ -5,7 +5,7 @@ TARGET = decimator
 CPP_SOURCES = decimator.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/delayline/Makefile
+++ b/seed/DSP/delayline/Makefile
@@ -5,7 +5,7 @@ TARGET = delayline
 CPP_SOURCES = delayline.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/drip/Makefile
+++ b/seed/DSP/drip/Makefile
@@ -6,7 +6,7 @@ TARGET = drip
 CPP_SOURCES = drip.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/dust/Makefile
+++ b/seed/DSP/dust/Makefile
@@ -5,7 +5,7 @@ TARGET = dust
 CPP_SOURCES = dust.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/faustnoise/Makefile
+++ b/seed/DSP/faustnoise/Makefile
@@ -5,7 +5,7 @@ TARGET = faustnoise
 CPP_SOURCES = faust.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/fir/Makefile
+++ b/seed/DSP/fir/Makefile
@@ -2,7 +2,7 @@
 TARGET = fir
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 CMSIS_DIR ?= $(LIBDAISY_DIR)/Drivers/CMSIS
 

--- a/seed/DSP/flanger/Makefile
+++ b/seed/DSP/flanger/Makefile
@@ -5,7 +5,7 @@ TARGET = flanger
 CPP_SOURCES = flanger.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/fm2/Makefile
+++ b/seed/DSP/fm2/Makefile
@@ -5,7 +5,7 @@ TARGET = fm2
 CPP_SOURCES = fm2.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/formantosc/Makefile
+++ b/seed/DSP/formantosc/Makefile
@@ -5,7 +5,7 @@ TARGET = formantosc
 CPP_SOURCES = formantosc.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/fractal_noise/Makefile
+++ b/seed/DSP/fractal_noise/Makefile
@@ -5,7 +5,7 @@ TARGET = fractal_noise
 CPP_SOURCES = fractal_noise.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/grainlet/Makefile
+++ b/seed/DSP/grainlet/Makefile
@@ -5,7 +5,7 @@ TARGET = grainlet
 CPP_SOURCES = grainlet.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/harmonic_osc/Makefile
+++ b/seed/DSP/harmonic_osc/Makefile
@@ -5,7 +5,7 @@ TARGET = harmonic_osc
 CPP_SOURCES = harmonic_osc.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/hihat/Makefile
+++ b/seed/DSP/hihat/Makefile
@@ -5,7 +5,7 @@ TARGET = hihat
 CPP_SOURCES = hihat.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/jitter/Makefile
+++ b/seed/DSP/jitter/Makefile
@@ -5,7 +5,7 @@ TARGET = jitter
 CPP_SOURCES = jitter.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/line/Makefile
+++ b/seed/DSP/line/Makefile
@@ -5,7 +5,7 @@ TARGET = line
 CPP_SOURCES = line.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/maytrig/Makefile
+++ b/seed/DSP/maytrig/Makefile
@@ -5,7 +5,7 @@ TARGET = maytrig
 CPP_SOURCES = maytrig.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/metro/Makefile
+++ b/seed/DSP/metro/Makefile
@@ -5,7 +5,7 @@ TARGET = metro
 CPP_SOURCES = metro.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/modalvoice/Makefile
+++ b/seed/DSP/modalvoice/Makefile
@@ -5,7 +5,7 @@ TARGET = modalvoice
 CPP_SOURCES = modalvoice.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/moogladder/Makefile
+++ b/seed/DSP/moogladder/Makefile
@@ -5,7 +5,7 @@ TARGET = moogladder
 CPP_SOURCES = moogladder.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/nlfilt/Makefile
+++ b/seed/DSP/nlfilt/Makefile
@@ -5,7 +5,7 @@ TARGET = nlfilt
 CPP_SOURCES = nlfilt.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/oscbank/Makefile
+++ b/seed/DSP/oscbank/Makefile
@@ -5,7 +5,7 @@ TARGET = oscbank
 CPP_SOURCES = oscbank.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/oscillator/Makefile
+++ b/seed/DSP/oscillator/Makefile
@@ -5,7 +5,7 @@ TARGET = oscillator
 CPP_SOURCES = oscillator.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/overdrive/Makefile
+++ b/seed/DSP/overdrive/Makefile
@@ -5,7 +5,7 @@ TARGET = overdrive
 CPP_SOURCES = overdrive.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/particle/Makefile
+++ b/seed/DSP/particle/Makefile
@@ -5,7 +5,7 @@ TARGET = particle
 CPP_SOURCES = particle.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/phaser/Makefile
+++ b/seed/DSP/phaser/Makefile
@@ -5,7 +5,7 @@ TARGET = phaser
 CPP_SOURCES = phaser.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/phasor/Makefile
+++ b/seed/DSP/phasor/Makefile
@@ -5,7 +5,7 @@ TARGET = phasor
 CPP_SOURCES = phasor.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/pitchshifter/Makefile
+++ b/seed/DSP/pitchshifter/Makefile
@@ -5,7 +5,7 @@ TARGET = pitchshifter
 CPP_SOURCES = pitchshifter.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/pluck/Makefile
+++ b/seed/DSP/pluck/Makefile
@@ -5,7 +5,7 @@ TARGET = pluck
 CPP_SOURCES = pluck.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/port/Makefile
+++ b/seed/DSP/port/Makefile
@@ -5,7 +5,7 @@ TARGET = port
 CPP_SOURCES = port.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/resonator/Makefile
+++ b/seed/DSP/resonator/Makefile
@@ -5,7 +5,7 @@ TARGET = resonator
 CPP_SOURCES = resonator.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/reverbsc/Makefile
+++ b/seed/DSP/reverbsc/Makefile
@@ -5,7 +5,7 @@ TARGET = reverbsc
 CPP_SOURCES = reverbsc.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/samplehold/Makefile
+++ b/seed/DSP/samplehold/Makefile
@@ -5,7 +5,7 @@ TARGET = samplehold
 CPP_SOURCES = samplehold.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/sampleratereducer/Makefile
+++ b/seed/DSP/sampleratereducer/Makefile
@@ -5,7 +5,7 @@ TARGET = sampleratereducer
 CPP_SOURCES = sampleratereducer.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/smooth_random/Makefile
+++ b/seed/DSP/smooth_random/Makefile
@@ -5,7 +5,7 @@ TARGET = smooth_random
 CPP_SOURCES = smooth_random.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/string/Makefile
+++ b/seed/DSP/string/Makefile
@@ -5,7 +5,7 @@ TARGET = string
 CPP_SOURCES = string.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/stringvoice/Makefile
+++ b/seed/DSP/stringvoice/Makefile
@@ -5,7 +5,7 @@ TARGET = stringvoice
 CPP_SOURCES = stringvoice.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/svf/Makefile
+++ b/seed/DSP/svf/Makefile
@@ -5,7 +5,7 @@ TARGET = svf
 CPP_SOURCES = svf.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/synthbassdrum/Makefile
+++ b/seed/DSP/synthbassdrum/Makefile
@@ -5,7 +5,7 @@ TARGET = synthbassdrum
 CPP_SOURCES = synthbassdrum.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/synthsnaredrum/Makefile
+++ b/seed/DSP/synthsnaredrum/Makefile
@@ -5,7 +5,7 @@ TARGET = synthsnaredrum
 CPP_SOURCES = synthsnaredrum.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/tone/Makefile
+++ b/seed/DSP/tone/Makefile
@@ -5,7 +5,7 @@ TARGET = tone
 CPP_SOURCES = tone.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/tremolo/Makefile
+++ b/seed/DSP/tremolo/Makefile
@@ -5,7 +5,7 @@ TARGET = tremolo
 CPP_SOURCES = tremolo.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/variableshapeosc/Makefile
+++ b/seed/DSP/variableshapeosc/Makefile
@@ -5,7 +5,7 @@ TARGET = variableshapeosc
 CPP_SOURCES = variableshapeosc.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/varisaw/Makefile
+++ b/seed/DSP/varisaw/Makefile
@@ -5,7 +5,7 @@ TARGET = varisaw
 CPP_SOURCES = varisaw.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/vosim/Makefile
+++ b/seed/DSP/vosim/Makefile
@@ -5,7 +5,7 @@ TARGET = vosim
 CPP_SOURCES = vosim.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/whitenoise/Makefile
+++ b/seed/DSP/whitenoise/Makefile
@@ -5,7 +5,7 @@ TARGET = whitenoise
 CPP_SOURCES = whitenoise.cpp
 
 # Library Locations
-LIBDAISY_DIR ?= ../../../libdaisy
+LIBDAISY_DIR ?= ../../../libDaisy
 DAISYSP_DIR ?= ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/DSP/zoscillator/Makefile
+++ b/seed/DSP/zoscillator/Makefile
@@ -5,7 +5,7 @@ TARGET = zoscillator
 CPP_SOURCES = zoscillator.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../../libdaisy
+LIBDAISY_DIR = ../../../libDaisy
 DAISYSP_DIR = ../../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/HWTest/Makefile
+++ b/seed/HWTest/Makefile
@@ -5,7 +5,7 @@ TARGET = HWTest
 CPP_SOURCES = HWTest.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic makefile.

--- a/seed/Knob/Makefile
+++ b/seed/Knob/Makefile
@@ -5,7 +5,7 @@ TARGET = Knob
 CPP_SOURCES = Knob.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic makefile.

--- a/seed/LCD_HD44780/Makefile
+++ b/seed/LCD_HD44780/Makefile
@@ -5,7 +5,7 @@ TARGET = lcd_hd44780
 CPP_SOURCES = lcd_hd44780.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic makefile.

--- a/seed/Logger/Makefile
+++ b/seed/Logger/Makefile
@@ -5,7 +5,7 @@ TARGET = Logger
 CPP_SOURCES = Logger.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Linker flags

--- a/seed/OLED/Makefile
+++ b/seed/OLED/Makefile
@@ -5,7 +5,7 @@ TARGET = OLED
 CPP_SOURCES = OLED.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic makefile.

--- a/seed/QSPI/Makefile
+++ b/seed/QSPI/Makefile
@@ -5,7 +5,7 @@ TARGET = QSPI
 CPP_SOURCES = QSPI.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/Ram/Makefile
+++ b/seed/Ram/Makefile
@@ -5,7 +5,7 @@ TARGET = Ram
 CPP_SOURCES = Ram.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.

--- a/seed/ReceiveTest/Makefile
+++ b/seed/ReceiveTest/Makefile
@@ -5,7 +5,7 @@ TARGET = ReceiveTest
 CPP_SOURCES = ReceiveTest.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic makefile.

--- a/seed/SDMMC/Makefile
+++ b/seed/SDMMC/Makefile
@@ -5,7 +5,7 @@ TARGET = SDMMC
 CPP_SOURCES = SDMMC.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Includes FatFS source files within project.

--- a/seed/USB_CDC/Makefile
+++ b/seed/USB_CDC/Makefile
@@ -5,7 +5,7 @@ TARGET = USB_CDC
 CPP_SOURCES = USB_CDC.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic makefile.

--- a/seed/USB_MIDI/Makefile
+++ b/seed/USB_MIDI/Makefile
@@ -5,7 +5,7 @@ TARGET = USB_MIDI
 CPP_SOURCES = USB_MIDI.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy/
+LIBDAISY_DIR = ../../libDaisy/
 DAISYSP_DIR = ../../DaisySP/
 
 # Core location, and generic Makefile.

--- a/seed/WavPlayer/Makefile
+++ b/seed/WavPlayer/Makefile
@@ -5,7 +5,7 @@ TARGET = WavPlayer
 CPP_SOURCES = WavPlayer.cpp
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Includes FatFS source files within project.

--- a/seed/bypass/Makefile
+++ b/seed/bypass/Makefile
@@ -6,7 +6,7 @@ CPP_SOURCES = bypass.cpp
 
 # Library Locations
 DAISYSP_DIR ?= ../../DaisySP
-LIBDAISY_DIR ?= ../../libdaisy
+LIBDAISY_DIR ?= ../../libDaisy
 
 # Core location, and generic Makefile.
 SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core

--- a/versio/Decimator/Makefile
+++ b/versio/Decimator/Makefile
@@ -7,7 +7,7 @@ CPP_SOURCES = Decimator.cpp
 #DEBUG=1
 
 # Library Locations
-LIBDAISY_DIR = ../../libdaisy
+LIBDAISY_DIR = ../../libDaisy
 DAISYSP_DIR = ../../DaisySP
 
 # Core location, and generic Makefile.


### PR DESCRIPTION
This should fix the consistency issue, that has given some people a compile error on mac/linux. 

I think the VS code files were updated to use the upper-case D character, while the actual Makefiles still had everything lower case. 

CI runs on linux so if there are any more issues, it should catch them now that the submodule has been updated.