### PR TITLE
Added typical audio setting functions to default generated project

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -253,6 +253,9 @@ def create_from_template(destination, board, libs, include_vs = False):
         f.write('int main(void)\n')
         f.write('{\n')
         f.write('\thw.Init();\n')
+        # Include Audio Setting Options
+        f.write('\thw.SetAudioBlockSize(4); // number of samples handled per callback\n')
+        f.write('\thw.SetAudioSampleRate(SaiHandle::Config::SampleRate::SAI_48KHZ);\n')
         if board != "seed" and board != "patch_sm":
             f.write('\thw.StartAdc();\n')
         f.write('\thw.StartAudio(AudioCallback);\n')


### PR DESCRIPTION
as the PR states this adds typical audio settings to the default generated project making it easier/clearer for people to update if they want.

At some point I think I'll change the samplerate setting to use float (especially once we can fine tune to ~any target samplerate), but not every board supports the numeric-argument version of the function. So for now it uses the `SaiHandle::Config::SampleRate` enum class version for all boards.