### PR TITLE
Fixes "wworkspace" typo in all examples' tasks.json files

### DIFF
--- a/field/KeyboardTest/.vscode/tasks.json
+++ b/field/KeyboardTest/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/field/Midi/.vscode/tasks.json
+++ b/field/Midi/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/field/Nimbus/.vscode/tasks.json
+++ b/field/Nimbus/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/field/chorus/.vscode/tasks.json
+++ b/field/chorus/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/field/flanger/.vscode/tasks.json
+++ b/field/flanger/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/field/modalvoice/.vscode/tasks.json
+++ b/field/modalvoice/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/field/phaser/.vscode/tasks.json
+++ b/field/phaser/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/field/sampler/.vscode/tasks.json
+++ b/field/sampler/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/field/stringvoice/.vscode/tasks.json
+++ b/field/stringvoice/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch/Compressor/.vscode/tasks.json
+++ b/patch/Compressor/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch/EnvelopeOscillator/.vscode/tasks.json
+++ b/patch/EnvelopeOscillator/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch/FilterBank/.vscode/tasks.json
+++ b/patch/FilterBank/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch/Midi/.vscode/tasks.json
+++ b/patch/Midi/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch/MultiDelay/.vscode/tasks.json
+++ b/patch/MultiDelay/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch/Nimbus/.vscode/tasks.json
+++ b/patch/Nimbus/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch/Noise/.vscode/tasks.json
+++ b/patch/Noise/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch/PluckEcho/.vscode/tasks.json
+++ b/patch/PluckEcho/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch/PolyOsc/.vscode/tasks.json
+++ b/patch/PolyOsc/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch/QuadEnvelope/.vscode/tasks.json
+++ b/patch/QuadEnvelope/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch/QuadMixer/.vscode/tasks.json
+++ b/patch/QuadMixer/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch/QuadraphonicMixer/.vscode/tasks.json
+++ b/patch/QuadraphonicMixer/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch/SampleAndHold/.vscode/tasks.json
+++ b/patch/SampleAndHold/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch/Sequencer/.vscode/tasks.json
+++ b/patch/Sequencer/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch/SequentialSwitch/.vscode/tasks.json
+++ b/patch/SequentialSwitch/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch/Svf/.vscode/tasks.json
+++ b/patch/Svf/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch/Torus/.vscode/tasks.json
+++ b/patch/Torus/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch/lfo/.vscode/tasks.json
+++ b/patch/lfo/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch/logic/.vscode/tasks.json
+++ b/patch/logic/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch/vco/.vscode/tasks.json
+++ b/patch/vco/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch/verb/.vscode/tasks.json
+++ b/patch/verb/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch_sm/EnvelopeExample/.vscode/tasks.json
+++ b/patch_sm/EnvelopeExample/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch_sm/GettingStarted/Audio_Settings/.vscode/tasks.json
+++ b/patch_sm/GettingStarted/Audio_Settings/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch_sm/GettingStarted/CV_Input/.vscode/tasks.json
+++ b/patch_sm/GettingStarted/CV_Input/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch_sm/GettingStarted/CV_Output/.vscode/tasks.json
+++ b/patch_sm/GettingStarted/CV_Output/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch_sm/GettingStarted/Gate_Input/.vscode/tasks.json
+++ b/patch_sm/GettingStarted/Gate_Input/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch_sm/GettingStarted/Gate_Output/.vscode/tasks.json
+++ b/patch_sm/GettingStarted/Gate_Output/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch_sm/GettingStarted/Momentary_Switch/.vscode/tasks.json
+++ b/patch_sm/GettingStarted/Momentary_Switch/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch_sm/GettingStarted/Pot_Input/.vscode/tasks.json
+++ b/patch_sm/GettingStarted/Pot_Input/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch_sm/GettingStarted/Toggle_Switch/.vscode/tasks.json
+++ b/patch_sm/GettingStarted/Toggle_Switch/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch_sm/HardwareTest/.vscode/tasks.json
+++ b/patch_sm/HardwareTest/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch_sm/Looper/.vscode/tasks.json
+++ b/patch_sm/Looper/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch_sm/PassthruExample/.vscode/tasks.json
+++ b/patch_sm/PassthruExample/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch_sm/RandomCvExample/.vscode/tasks.json
+++ b/patch_sm/RandomCvExample/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch_sm/ReverbExample/.vscode/tasks.json
+++ b/patch_sm/ReverbExample/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch_sm/SimpleOscillator/.vscode/tasks.json
+++ b/patch_sm/SimpleOscillator/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/patch_sm/TripleSaw/.vscode/tasks.json
+++ b/patch_sm/TripleSaw/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/petal/CombFilter/.vscode/tasks.json
+++ b/petal/CombFilter/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/petal/Distortion/.vscode/tasks.json
+++ b/petal/Distortion/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/petal/FilterBank/.vscode/tasks.json
+++ b/petal/FilterBank/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/petal/GeneralFunctionTest/.vscode/tasks.json
+++ b/petal/GeneralFunctionTest/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/petal/Looper/.vscode/tasks.json
+++ b/petal/Looper/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/petal/MultiDelay/.vscode/tasks.json
+++ b/petal/MultiDelay/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/petal/MultiEffect/.vscode/tasks.json
+++ b/petal/MultiEffect/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/petal/Verb/.vscode/tasks.json
+++ b/petal/Verb/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/petal/chorus/.vscode/tasks.json
+++ b/petal/chorus/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/petal/flanger/.vscode/tasks.json
+++ b/petal/flanger/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/petal/phaser/.vscode/tasks.json
+++ b/petal/phaser/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/petal/tremolo/.vscode/tasks.json
+++ b/petal/tremolo/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/pod/ChordMachine/.vscode/tasks.json
+++ b/pod/ChordMachine/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/pod/Encoder/.vscode/tasks.json
+++ b/pod/Encoder/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/pod/EuclideanDrums/.vscode/tasks.json
+++ b/pod/EuclideanDrums/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/pod/Looper/.vscode/tasks.json
+++ b/pod/Looper/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/pod/Midi/.vscode/tasks.json
+++ b/pod/Midi/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/pod/MultiEffect/.vscode/tasks.json
+++ b/pod/MultiEffect/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/pod/MusicBox/.vscode/tasks.json
+++ b/pod/MusicBox/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/pod/SimpleButton/.vscode/tasks.json
+++ b/pod/SimpleButton/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/pod/SimpleLed/.vscode/tasks.json
+++ b/pod/SimpleLed/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/pod/SimpleOscillator/.vscode/tasks.json
+++ b/pod/SimpleOscillator/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/pod/StepSequencer/.vscode/tasks.json
+++ b/pod/StepSequencer/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/pod/SynthVoice/.vscode/tasks.json
+++ b/pod/SynthVoice/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/Blink/.vscode/tasks.json
+++ b/seed/Blink/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/Button/.vscode/tasks.json
+++ b/seed/Button/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/Drum/.vscode/tasks.json
+++ b/seed/DSP/Drum/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/Osc/.vscode/tasks.json
+++ b/seed/DSP/Osc/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/adenv/.vscode/tasks.json
+++ b/seed/DSP/adenv/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/adsr/.vscode/tasks.json
+++ b/seed/DSP/adsr/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/allpass/.vscode/tasks.json
+++ b/seed/DSP/allpass/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/analogbassdrum/.vscode/tasks.json
+++ b/seed/DSP/analogbassdrum/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/analogsnaredrum/.vscode/tasks.json
+++ b/seed/DSP/analogsnaredrum/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/atone/.vscode/tasks.json
+++ b/seed/DSP/atone/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/autowah/.vscode/tasks.json
+++ b/seed/DSP/autowah/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/balance/.vscode/tasks.json
+++ b/seed/DSP/balance/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/biquad/.vscode/tasks.json
+++ b/seed/DSP/biquad/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/bitcrush/.vscode/tasks.json
+++ b/seed/DSP/bitcrush/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/blosc/.vscode/tasks.json
+++ b/seed/DSP/blosc/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/chorus/.vscode/tasks.json
+++ b/seed/DSP/chorus/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/clockednoise/.vscode/tasks.json
+++ b/seed/DSP/clockednoise/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/comb/.vscode/tasks.json
+++ b/seed/DSP/comb/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/compressor/.vscode/tasks.json
+++ b/seed/DSP/compressor/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/crossfade/.vscode/tasks.json
+++ b/seed/DSP/crossfade/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/dcblock/.vscode/tasks.json
+++ b/seed/DSP/dcblock/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/decimator/.vscode/tasks.json
+++ b/seed/DSP/decimator/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/delayline/.vscode/tasks.json
+++ b/seed/DSP/delayline/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/drip/.vscode/tasks.json
+++ b/seed/DSP/drip/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/dust/.vscode/tasks.json
+++ b/seed/DSP/dust/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/faustnoise/.vscode/tasks.json
+++ b/seed/DSP/faustnoise/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/fir/.vscode/tasks.json
+++ b/seed/DSP/fir/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/flanger/.vscode/tasks.json
+++ b/seed/DSP/flanger/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/fm2/.vscode/tasks.json
+++ b/seed/DSP/fm2/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/formantosc/.vscode/tasks.json
+++ b/seed/DSP/formantosc/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/fractal_noise/.vscode/tasks.json
+++ b/seed/DSP/fractal_noise/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/grainlet/.vscode/tasks.json
+++ b/seed/DSP/grainlet/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/harmonic_osc/.vscode/tasks.json
+++ b/seed/DSP/harmonic_osc/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/hihat/.vscode/tasks.json
+++ b/seed/DSP/hihat/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/jitter/.vscode/tasks.json
+++ b/seed/DSP/jitter/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/line/.vscode/tasks.json
+++ b/seed/DSP/line/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/maytrig/.vscode/tasks.json
+++ b/seed/DSP/maytrig/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/metro/.vscode/tasks.json
+++ b/seed/DSP/metro/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/modalvoice/.vscode/tasks.json
+++ b/seed/DSP/modalvoice/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/moogladder/.vscode/tasks.json
+++ b/seed/DSP/moogladder/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/nlfilt/.vscode/tasks.json
+++ b/seed/DSP/nlfilt/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/oscbank/.vscode/tasks.json
+++ b/seed/DSP/oscbank/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/oscillator/.vscode/tasks.json
+++ b/seed/DSP/oscillator/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/overdrive/.vscode/tasks.json
+++ b/seed/DSP/overdrive/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/particle/.vscode/tasks.json
+++ b/seed/DSP/particle/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/phaser/.vscode/tasks.json
+++ b/seed/DSP/phaser/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/phasor/.vscode/tasks.json
+++ b/seed/DSP/phasor/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/pitchshifter/.vscode/tasks.json
+++ b/seed/DSP/pitchshifter/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/pluck/.vscode/tasks.json
+++ b/seed/DSP/pluck/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/port/.vscode/tasks.json
+++ b/seed/DSP/port/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/resonator/.vscode/tasks.json
+++ b/seed/DSP/resonator/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/reverbsc/.vscode/tasks.json
+++ b/seed/DSP/reverbsc/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/samplehold/.vscode/tasks.json
+++ b/seed/DSP/samplehold/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/sampleratereducer/.vscode/tasks.json
+++ b/seed/DSP/sampleratereducer/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/smooth_random/.vscode/tasks.json
+++ b/seed/DSP/smooth_random/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/string/.vscode/tasks.json
+++ b/seed/DSP/string/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/stringvoice/.vscode/tasks.json
+++ b/seed/DSP/stringvoice/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/svf/.vscode/tasks.json
+++ b/seed/DSP/svf/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/synthbassdrum/.vscode/tasks.json
+++ b/seed/DSP/synthbassdrum/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/synthsnaredrum/.vscode/tasks.json
+++ b/seed/DSP/synthsnaredrum/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/tone/.vscode/tasks.json
+++ b/seed/DSP/tone/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/tremolo/.vscode/tasks.json
+++ b/seed/DSP/tremolo/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/variableshapeosc/.vscode/tasks.json
+++ b/seed/DSP/variableshapeosc/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/varisaw/.vscode/tasks.json
+++ b/seed/DSP/varisaw/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/vosim/.vscode/tasks.json
+++ b/seed/DSP/vosim/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/whitenoise/.vscode/tasks.json
+++ b/seed/DSP/whitenoise/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/DSP/zoscillator/.vscode/tasks.json
+++ b/seed/DSP/zoscillator/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/HWTest/.vscode/tasks.json
+++ b/seed/HWTest/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/Knob/.vscode/tasks.json
+++ b/seed/Knob/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/LCD_HD44780/.vscode/tasks.json
+++ b/seed/LCD_HD44780/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/Logger/.vscode/tasks.json
+++ b/seed/Logger/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/OLED/.vscode/tasks.json
+++ b/seed/OLED/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/QSPI/.vscode/tasks.json
+++ b/seed/QSPI/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/Ram/.vscode/tasks.json
+++ b/seed/Ram/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/ReceiveTest/.vscode/tasks.json
+++ b/seed/ReceiveTest/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/SDMMC/.vscode/tasks.json
+++ b/seed/SDMMC/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/USB_CDC/.vscode/tasks.json
+++ b/seed/USB_CDC/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/USB_MIDI/.vscode/tasks.json
+++ b/seed/USB_MIDI/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/WavPlayer/.vscode/tasks.json
+++ b/seed/WavPlayer/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/bypass/.vscode/tasks.json
+++ b/seed/bypass/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"

--- a/utils/Template/.vscode/tasks.json
+++ b/utils/Template/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/@LIBDAISY_DIR@"
+        "cwd": "${workspaceFolder}/@LIBDAISY_DIR@"
       },
       "problemMatcher": [
         "$gcc"

--- a/versio/Decimator/.vscode/tasks.json
+++ b/versio/Decimator/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${wworkspaceFolder}/../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"


### PR DESCRIPTION
fixed typo where cwd was set to {wworkspaceFolder} instead of {workspaceFolder}

Fixed it in the template project to create new projects, and ran `./helper.py update` to fix it in all examples.