### PR TITLE
fixed update --include_vgdb usage errors

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -143,7 +143,7 @@ def copy_project(destination, source, include_vs=False):
     if os.path.isdir(srcAbs):
         # Then make a copy of the folder renaming it to be the same
         if include_vs:
-            shutil.copytree(srcAbs, destAbs)
+            shutil.copytree(srcAbs, destAbs, ignore = shutil.ignore_patterns('VisualGDB'))
         else:
             shutil.copytree(
                 srcAbs, destAbs, ignore = shutil.ignore_patterns('vs', 'Template.sln'))

--- a/helper.py
+++ b/helper.py
@@ -106,7 +106,7 @@ def update_project(destination, libs, include_vs=False):
     libs = pathlib.Path(libs).as_posix()
     cp_patts = ['.vscode/*']
     if include_vs:
-        cp_patts.append('*.sln', '*.vgdbsettings', 'vs/*')
+        cp_patts.extend(['*.sln', '*.vgdbsettings', 'vs/*'])
     cplists = list(glob.glob(tdir+os.path.sep+pat) for pat in cp_patts)
     f_to_cp = list(item for sublist in cplists for item in sublist)
     libs = pathlib.Path(os.path.relpath(libs, destination)).as_posix()
@@ -114,11 +114,14 @@ def update_project(destination, libs, include_vs=False):
         sname = os.path.abspath(f)
         dname = os.path.abspath(sname.replace(tdir, basedir)).replace('Template', proj_name)
         dir_path = os.path.dirname(dname)
-        if not os.path.isdir(dir_path):
-            os.mkdir(dir_path)
         print('copying: {} to {}'.format(
             os.path.relpath(sname), os.path.relpath(dname)))
-        shutil.copyfile(sname, dname)
+        if not os.path.isdir(dir_path):
+            os.mkdir(dir_path)
+        if os.path.isdir(sname):
+            shutil.copytree(sname, dname)
+        else:
+            shutil.copyfile(sname, dname)
         rewrite_replace(dname, 'Template', proj_name)
 
         rewrite_replace(dname, '@LIBDAISY_DIR@', libs + '/libDaisy')

--- a/helper.py
+++ b/helper.py
@@ -101,7 +101,10 @@ def update_project(destination, libs, include_vs=False):
     if len(f_to_rm) > 0:
         for f in f_to_rm:
             print('deleting: {}'.format(os.path.relpath(f)))
-            os.remove(f)
+            if os.path.isdir(f):
+                shutil.rmtree(f)
+            else:
+                os.remove(f)
     # Copying
     libs = pathlib.Path(libs).as_posix()
     cp_patts = ['.vscode/*']
@@ -122,10 +125,9 @@ def update_project(destination, libs, include_vs=False):
             shutil.copytree(sname, dname)
         else:
             shutil.copyfile(sname, dname)
-        rewrite_replace(dname, 'Template', proj_name)
-
-        rewrite_replace(dname, '@LIBDAISY_DIR@', libs + '/libDaisy')
-        rewrite_replace(dname, '@DAISYSP_DIR@', libs + '/DaisySP')
+            rewrite_replace(dname, 'Template', proj_name)
+            rewrite_replace(dname, '@LIBDAISY_DIR@', libs + '/libDaisy')
+            rewrite_replace(dname, '@DAISYSP_DIR@', libs + '/DaisySP')
 
 
 # Called via the 'copy' operation


### PR DESCRIPTION
Fixes issues when trying to run `helper.py update --include_vgdb`

Also prevents copying of `vs/VisualGDB` file tree that is added by VS VisualGDB when compiling a project.