### PR TITLE
Patchsm blocksize update

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -259,7 +259,8 @@ def create_from_template(destination, board, libs, include_vs = False):
         f.write('{\n')
         f.write('\thw.Init();\n')
         # Include Audio Setting Options
-        f.write('\thw.SetAudioBlockSize(4); // number of samples handled per callback\n')
+        if board != 'patch_sm':
+            f.write('\thw.SetAudioBlockSize(4); // number of samples handled per callback\n')
         f.write('\thw.SetAudioSampleRate(SaiHandle::Config::SampleRate::SAI_48KHZ);\n')
         if board != "seed" and board != "patch_sm":
             f.write('\thw.StartAdc();\n')

--- a/patch_sm/GettingStarted/Audio_Settings/Audio_Settings.cpp
+++ b/patch_sm/GettingStarted/Audio_Settings/Audio_Settings.cpp
@@ -14,13 +14,11 @@ DaisyPatchSM patch;
 
 /** Callback for processing and synthesizing audio
  *
- *  The default size is very small (just 4 samples per channel). This means the
- * callback is being called at 16kHz.
+ *  The default size is 48 samples per channel. This means the
+ * callback is being called at 1kHz.
  *
- *  This size is acceptable for many applications, and provides an extremely low
- * latency from input to output. However, you can change this size by calling
- * patch.SetAudioBlockSize(desired_size). When running complex DSP it can be more
- * efficient to do the processing on larger chunks at a time.
+ *   You can change this size by calling patch.SetAudioBlockSize(desired_size). 
+ *  When running complex DSP it is more efficient to do the processing on larger chunks at a time.
  *
  */
 void AudioCallback(AudioHandle::InputBuffer  in,
@@ -40,7 +38,7 @@ void AudioCallback(AudioHandle::InputBuffer  in,
 int main(void)
 {
     /** Initialize the patch_sm object 
-    * This sets the blocksize to its default of 4 samples.
+    * This sets the blocksize to its default of 48 samples.
     * This sets the samplerate to its default of 48kHz.
     */
     patch.Init();
@@ -48,8 +46,8 @@ int main(void)
     /** Set the samplerate to 96kHz */
     patch.SetAudioSampleRate(96000);
 
-    /** Set the blocksize to 4 samples */
-    patch.SetAudioBlockSize(4);
+    /** Set the blocksize to 48 samples */
+    patch.SetAudioBlockSize(48);
 
     /** Start the audio callback */
     patch.StartAudio(AudioCallback);

--- a/patch_sm/PassthruExample/PassthruExample.cpp
+++ b/patch_sm/PassthruExample/PassthruExample.cpp
@@ -21,13 +21,11 @@ DaisyPatchSM patch;
  *  where n is the specific sample.
  *  There are "size" samples in each array.
  *
- *  The default size is very small (just 4 samples per channel). This means the
- * callback is being called at 16kHz.
+ *  The default size is 48 samples per channel. This means the
+ * callback is being called at 1kHz.
  *
- *  This size is acceptable for many applications, and provides an extremely low
- * latency from input to output. However, you can change this size by calling
- * patch.SetAudioBlockSize(desired_size). When running complex DSP it can be more
- * efficient to do the processing on larger chunks at a time.
+ *   You can change this size by calling patch.SetAudioBlockSize(desired_size). 
+ *  When running complex DSP it is more efficient to do the processing on larger chunks at a time.
  *
  */
 void AudioCallback(AudioHandle::InputBuffer  in,

--- a/patch_sm/ReverbExample/ReverbExample_comments.cpp
+++ b/patch_sm/ReverbExample/ReverbExample_comments.cpp
@@ -22,13 +22,11 @@ ReverbSc reverb;
  *  where n is the specific sample.
  *  There are "size" samples in each array.
  *
- *  The default size is very small (just 4 samples per channel). This means the
- * callback is being called at 16kHz.
+ *  The default size is 48 samples per channel. This means the
+ * callback is being called at 1kHz.
  *
- *  This size is acceptable for many applications, and provides an extremely low
- * latency from input to output. However, you can change this size by calling
- * patch.SetAudioBlockSize(desired_size). When running complex DSP it can be more
- * efficient to do the processing on larger chunks at a time.
+ *   You can change this size by calling patch.SetAudioBlockSize(desired_size). 
+ *  When running complex DSP it is more efficient to do the processing on larger chunks at a time.
  *
  */
 void AudioCallback(AudioHandle::InputBuffer  in,

--- a/patch_sm/TripleSaw/TripleSaw_comments.cpp
+++ b/patch_sm/TripleSaw/TripleSaw_comments.cpp
@@ -27,13 +27,11 @@ Oscillator osc_a, osc_b, osc_c;
  *  where n is the specific sample.
  *  There are "size" samples in each array.
  *
- *  The default size is very small (just 4 samples per channel). This means the
- * callback is being called at 16kHz.
+ *  The default size is 48 samples per channel. This means the
+ * callback is being called at 1kHz.
  *
- *  This size is acceptable for many applications, and provides an extremely low
- * latency from input to output. However, you can change this size by calling
- * hw.SetAudioBlockSize(desired_size). When running complex DSP it can be more
- * efficient to do the processing on larger chunks at a time.
+ *   You can change this size by calling patch.SetAudioBlockSize(desired_size). 
+ *  When running complex DSP it is more efficient to do the processing on larger chunks at a time.
  *
  */
 void AudioCallback(AudioHandle::InputBuffer  in,


### PR DESCRIPTION
- Helper.py no longer overrides blocksize when board is set to patch_sm
- Change commented examples to reflect new patch_sm blocksize