### PR TITLE
fix: tree structure on tasks

### DIFF
--- a/seed/Drum/.vscode/tasks.json
+++ b/seed/Drum/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${workspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"
@@ -94,7 +94,7 @@
       "command": "make",
       "label": "build_daisysp",
       "options": {
-        "cwd": "${workspaceFolder}/../../../DaisySP"
+        "cwd": "${workspaceFolder}/../../DaisySP"
       },
       "problemMatcher": [
         "$gcc"

--- a/seed/Osc/.vscode/tasks.json
+++ b/seed/Osc/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${workspaceFolder}/../../../libDaisy"
+        "cwd": "${workspaceFolder}/../../libDaisy"
       },
       "problemMatcher": [
         "$gcc"
@@ -94,7 +94,7 @@
       "command": "make",
       "label": "build_daisysp",
       "options": {
-        "cwd": "${workspaceFolder}/../../../DaisySP"
+        "cwd": "${workspaceFolder}/../../DaisySP"
       },
       "problemMatcher": [
         "$gcc"


### PR DESCRIPTION
A small fix on the [issue](https://github.com/electro-smith/DaisyExamples/issues/286) I opened a while ago. 

On the `tasks.json` of seed/osc and seed/Drum I changed `"${workspaceFolder}/../../../DaisySP"` to `"${workspaceFolder}/../../DaisySP"`.