### PR TITLE
fixed vscode include pathing in examples

### DIFF
--- a/seed/Osc/.vscode/c_cpp_properties.json
+++ b/seed/Osc/.vscode/c_cpp_properties.json
@@ -11,8 +11,8 @@
       ],
       "includePath": [
         "${workspaceFolder}/**",
-        "${workspaceFolder}/../../../libDaisy/**",
-        "${workspaceFolder}/../../../DaisySP/**"
+        "${workspaceFolder}/../../libDaisy/**",
+        "${workspaceFolder}/../../DaisySP/**"
       ],
       "name": "Win32",
       "windowsSdkVersion": "10.0.17763.0"
@@ -28,8 +28,8 @@
       ],
       "includePath": [
         "${workspaceFolder}/**",
-        "${workspaceFolder}/../../../libDaisy/**",
-        "${workspaceFolder}/../../../DaisySP/**"
+        "${workspaceFolder}/../../libDaisy/**",
+        "${workspaceFolder}/../../DaisySP/**"
       ],
       "name": "macOS"
     }


### PR DESCRIPTION
Changed seed/osc .vscode include pathing to match all other examples. I don't know if there are other issues like this one. I just wanted to practice my gh workflow :). 