### PR TITLE
Update clang-format-lint-action version

### DIFF
--- a/.github/workflows/fix_style.yml
+++ b/.github/workflows/fix_style.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: DoozyX/clang-format-lint-action@v0.11
+    - uses: DoozyX/clang-format-lint-action@v0.18.2
       with:
         source: '.'
         exclude: './DaisySP ./libDaisy ./cube ./utils ./resources ./**/experimental'


### PR DESCRIPTION
This fixes the `fix-style` action which has been failing due to out of date python `distutils`